### PR TITLE
Close editors before running game

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,7 @@ if(UNIX OR MINGW)
 endif()
 
 # GLFW
+set(GLFW_BUILD_DOCS OFF CACHE BOOL "Don't build GLFW docs" FORCE)
 set(GLFW_BUILD_EXAMPLES OFF CACHE BOOL "Don't build GLFW examples" FORCE)
 set(GLFW_BUILD_TESTS OFF CACHE BOOL "Don't build GLFW tests" FORCE)
 add_subdirectory(externals/glfw)

--- a/src/Editor/Editor.cpp
+++ b/src/Editor/Editor.cpp
@@ -77,6 +77,7 @@ void Editor::SetVisible(bool visible) {
 void Editor::Play() {
     Save();
     SetVisible(false);
+    resourceList.HideEditors();
 }
 
 void Editor::NewHymn() {

--- a/src/Editor/GUI/ResourceList.cpp
+++ b/src/Editor/GUI/ResourceList.cpp
@@ -160,3 +160,21 @@ void ResourceList::SetEntitySelectedCallback(std::function<void(Entity*)> callba
     hasEntitySelectedCallback = true;
     entitySelectedCallback = callback;
 }
+
+void ResourceList::HideEditors() {
+    for (auto& editor : entityEditors) {
+        editor.second.SetVisible(false);
+    }
+    
+    for (auto& editor : modelEditors) {
+        editor.second.SetVisible(false);
+    }
+    
+    for (auto& editor : textureEditors) {
+        editor.second.SetVisible(false);
+    }
+    
+    for (auto& editor : soundEditors) {
+        editor.second.SetVisible(false);
+    }
+}

--- a/src/Editor/GUI/ResourceList.cpp
+++ b/src/Editor/GUI/ResourceList.cpp
@@ -156,11 +156,6 @@ void ResourceList::SetVisible(bool visible) {
     this->visible = visible;
 }
 
-void ResourceList::SetEntitySelectedCallback(std::function<void(Entity*)> callback) {
-    hasEntitySelectedCallback = true;
-    entitySelectedCallback = callback;
-}
-
 void ResourceList::HideEditors() {
     for (auto& editor : entityEditors) {
         editor.second.SetVisible(false);

--- a/src/Editor/GUI/ResourceList.hpp
+++ b/src/Editor/GUI/ResourceList.hpp
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <functional>
 #include <map>
 #include "Editors/EntityEditor.hpp"
 #include "Editors/ModelEditor.hpp"
@@ -35,12 +34,6 @@ namespace GUI {
              */
             void SetVisible(bool visible);
             
-            /// Set function to call when an entity has been selected.
-            /**
-             * @param callback Function to call.
-             */
-            void SetEntitySelectedCallback(std::function<void(Entity*)> callback);
-            
             /// Hide all editors.
             /**
              * Needs to be called before playing the game or old editors with stale pointers could be shown when returning to the editor.
@@ -54,8 +47,5 @@ namespace GUI {
             std::map<Geometry::OBJModel*, ModelEditor> modelEditors;
             std::map<Texture2D*, TextureEditor> textureEditors;
             std::map<Audio::SoundBuffer*, SoundEditor> soundEditors;
-            
-            bool hasEntitySelectedCallback = false;
-            std::function<void(Entity*)> entitySelectedCallback;
     };
 }

--- a/src/Editor/GUI/ResourceList.hpp
+++ b/src/Editor/GUI/ResourceList.hpp
@@ -41,6 +41,12 @@ namespace GUI {
              */
             void SetEntitySelectedCallback(std::function<void(Entity*)> callback);
             
+            /// Hide all editors.
+            /**
+             * Needs to be called before playing the game or old editors with stale pointers could be shown when returning to the editor.
+             */
+            void HideEditors();
+            
         private:
             bool visible = false;
             


### PR DESCRIPTION
Close editors so they aren't using stale pointer values, thus corrupting the project, when returning to the editor after playing.