### PR TITLE
Options to disable viewing icons

### DIFF
--- a/src/Editor/Editor.cpp
+++ b/src/Editor/Editor.cpp
@@ -32,6 +32,23 @@ void Editor::Show() {
             ImGui::EndMenu();
         }
         
+        // View menu.
+        if (ImGui::BeginMenu("View")) {
+            static bool soundSources = EditorSettings::GetInstance().GetBool("Sound Source Icons");
+            ImGui::MenuItem("Sound Sources", "", &soundSources);
+            EditorSettings::GetInstance().SetBool("Sound Source Icons", soundSources);
+            
+            static bool particleEmitters = EditorSettings::GetInstance().GetBool("Particle Emitter Icons");
+            ImGui::MenuItem("Particle Emitters", "", &particleEmitters);
+            EditorSettings::GetInstance().SetBool("Particle Emitter Icons", particleEmitters);
+            
+            static bool lightSources = EditorSettings::GetInstance().GetBool("Light Source Icons");
+            ImGui::MenuItem("Light Sources", "", &lightSources);
+            EditorSettings::GetInstance().SetBool("Light Source Icons", lightSources);
+            
+            ImGui::EndMenu();
+        }
+        
         // Play
         if (ImGui::BeginMenu("Play")) {
             if (ImGui::MenuItem("Play", "F5")) {

--- a/src/Editor/Util/EditorSettings.cpp
+++ b/src/Editor/Util/EditorSettings.cpp
@@ -14,6 +14,7 @@ EditorSettings::EditorSettings() {
     
     AddBoolSetting("Sound Source Icons", "View", "Sound Source Icons", true);
     AddBoolSetting("Particle Emitter Icons", "View", "Particle Emitter Icons", true);
+    AddBoolSetting("Light Source Icons", "View", "Light Source Icons", true);
 }
 
 EditorSettings& EditorSettings::GetInstance() {

--- a/src/Editor/Util/EditorSettings.cpp
+++ b/src/Editor/Util/EditorSettings.cpp
@@ -13,6 +13,7 @@ EditorSettings::EditorSettings() {
     AddLongSetting("Height", "Graphics", "Height", 600);
     
     AddBoolSetting("Sound Source Icons", "View", "Sound Source Icons", true);
+    AddBoolSetting("Particle Emitter Icons", "View", "Particle Emitter Icons", true);
 }
 
 EditorSettings& EditorSettings::GetInstance() {

--- a/src/Editor/Util/EditorSettings.cpp
+++ b/src/Editor/Util/EditorSettings.cpp
@@ -11,6 +11,8 @@ EditorSettings::EditorSettings() {
     
     AddLongSetting("Width", "Graphics", "Width", 800);
     AddLongSetting("Height", "Graphics", "Height", 600);
+    
+    AddBoolSetting("Sound Source Icons", "View", "Sound Source Icons", true);
 }
 
 EditorSettings& EditorSettings::GetInstance() {

--- a/src/Editor/Util/EditorSettings.hpp
+++ b/src/Editor/Util/EditorSettings.hpp
@@ -5,12 +5,13 @@
 /// %Settings for the editor.
 /**
  * Available settings:
- * Name          | Description                     | Type | Default Value
- * ------------- | ------------------------------- | ---- | -------------
- * Logging       | Output a log file.              | bool | false
- * Debug Context | Create an OpenGL Debug Context. | bool | false
- * Width         | Width of the editor window.     | long | 800
- * Height        | Height of the editor window.    | long | 600
+ * Name                   | Description                     | Type | Default Value
+ * ---------------------- | ------------------------------- | ---- | -------------
+ * Logging                | Output a log file.              | bool | false
+ * Debug Context          | Create an OpenGL Debug Context. | bool | false
+ * Width                  | Width of the editor window.     | long | 800
+ * Height                 | Height of the editor window.    | long | 600
+ * Sound Source Icons     | Show sound source icons.        | bool | true
  */
 class EditorSettings : public Settings {
     public:

--- a/src/Editor/Util/EditorSettings.hpp
+++ b/src/Editor/Util/EditorSettings.hpp
@@ -12,6 +12,7 @@
  * Width                  | Width of the editor window.     | long | 800
  * Height                 | Height of the editor window.    | long | 600
  * Sound Source Icons     | Show sound source icons.        | bool | true
+ * Particle Emitter Icons | Show particle emitter icons.    | bool | true
  */
 class EditorSettings : public Settings {
     public:

--- a/src/Editor/Util/EditorSettings.hpp
+++ b/src/Editor/Util/EditorSettings.hpp
@@ -13,6 +13,7 @@
  * Height                 | Height of the editor window.    | long | 600
  * Sound Source Icons     | Show sound source icons.        | bool | true
  * Particle Emitter Icons | Show particle emitter icons.    | bool | true
+ * Light Source Icons     | Show light source icons.        | bool | true
  */
 class EditorSettings : public Settings {
     public:

--- a/src/Editor/main.cpp
+++ b/src/Editor/main.cpp
@@ -65,7 +65,7 @@ int main() {
             
             if (editor->IsVisible()) {
                 Hymn().activeScene.ClearKilled();
-                Hymn().Render(EditorSettings::GetInstance().GetBool("Sound Source Icons"), true, true);
+                Hymn().Render(EditorSettings::GetInstance().GetBool("Sound Source Icons"), EditorSettings::GetInstance().GetBool("Particle Emitter Icons"), true);
                 
                 editor->Show();
             } else {

--- a/src/Editor/main.cpp
+++ b/src/Editor/main.cpp
@@ -65,7 +65,7 @@ int main() {
             
             if (editor->IsVisible()) {
                 Hymn().activeScene.ClearKilled();
-                Hymn().Render(EditorSettings::GetInstance().GetBool("Sound Source Icons"), EditorSettings::GetInstance().GetBool("Particle Emitter Icons"), true);
+                Hymn().Render(EditorSettings::GetInstance().GetBool("Sound Source Icons"), EditorSettings::GetInstance().GetBool("Particle Emitter Icons"), EditorSettings::GetInstance().GetBool("Light Source Icons"));
                 
                 editor->Show();
             } else {

--- a/src/Editor/main.cpp
+++ b/src/Editor/main.cpp
@@ -65,7 +65,7 @@ int main() {
             
             if (editor->IsVisible()) {
                 Hymn().activeScene.ClearKilled();
-                Hymn().Render(true);
+                Hymn().Render(true, true, true);
                 
                 editor->Show();
             } else {

--- a/src/Editor/main.cpp
+++ b/src/Editor/main.cpp
@@ -65,7 +65,7 @@ int main() {
             
             if (editor->IsVisible()) {
                 Hymn().activeScene.ClearKilled();
-                Hymn().Render(true, true, true);
+                Hymn().Render(EditorSettings::GetInstance().GetBool("Sound Source Icons"), true, true);
                 
                 editor->Show();
             } else {

--- a/src/Engine/Hymn.cpp
+++ b/src/Engine/Hymn.cpp
@@ -205,14 +205,14 @@ void ActiveHymn::Update(float deltaTime) {
     }
 }
 
-void ActiveHymn::Render(bool editorRendering) {
+void ActiveHymn::Render(bool soundSources, bool particleEmitters, bool lightSources) {
     { PROFILE("Render scene");
         Managers().renderManager->Render(activeScene);
     }
     
-    if (editorRendering) {
+    if (soundSources || particleEmitters || lightSources) {
         { PROFILE("Render editor entities");
-            Managers().renderManager->RenderEditorEntities(activeScene);
+            Managers().renderManager->RenderEditorEntities(activeScene, soundSources, particleEmitters, lightSources);
         }
     }
     

--- a/src/Engine/Hymn.hpp
+++ b/src/Engine/Hymn.hpp
@@ -49,9 +49,11 @@ class ActiveHymn {
         
         /// Render the active scene.
         /**
-         * @param editorRendering Whether to render editor entities.
+         * @param soundSources Whether to show sound sources.
+         * @param particleEmitters Whether to show particle emitters.
+         * @param lightSources Whether to show light sources.
          */
-        void Render(bool editorRendering = false);
+        void Render(bool soundSources = false, bool particleEmitters = false, bool lightSources = false);
         
         /// The active scene.
         Scene activeScene;

--- a/src/Engine/Manager/RenderManager.cpp
+++ b/src/Engine/Manager/RenderManager.cpp
@@ -213,9 +213,10 @@ void RenderManager::RenderEditorEntities(Scene& scene, bool soundSources, bool p
         glUniform3fv(editorEntityShaderProgram->GetUniformLocation("cameraUp"), 1, &up[0]);
         glUniform1i(editorEntityShaderProgram->GetUniformLocation("baseImage"), 0);
         
+        glActiveTexture(GL_TEXTURE0);
+        
         // Render sound sources.
         if (soundSources) {
-            glActiveTexture(GL_TEXTURE0);
             glBindTexture(GL_TEXTURE_2D, soundSourceTexture->GetTextureID());
             
             for (SoundSource* soundSource : scene.GetComponents<SoundSource>())

--- a/src/Engine/Manager/RenderManager.cpp
+++ b/src/Engine/Manager/RenderManager.cpp
@@ -183,7 +183,7 @@ void RenderManager::Render(Scene& scene) {
     }
 }
 
-void RenderManager::RenderEditorEntities(Scene& scene) {
+void RenderManager::RenderEditorEntities(Scene& scene, bool soundSources, bool particleEmitters, bool lightSources) {
     // Find camera entity.
     Entity* camera = nullptr;
     std::vector<Lens*> lenses = scene.GetComponents<Lens>();
@@ -214,29 +214,35 @@ void RenderManager::RenderEditorEntities(Scene& scene) {
         glUniform1i(editorEntityShaderProgram->GetUniformLocation("baseImage"), 0);
         
         // Render sound sources.
-        glActiveTexture(GL_TEXTURE0);
-        glBindTexture(GL_TEXTURE_2D, soundSourceTexture->GetTextureID());
-        
-        for (SoundSource* soundSource : scene.GetComponents<SoundSource>())
-            RenderEditorEntity(soundSource);
+        if (soundSources) {
+            glActiveTexture(GL_TEXTURE0);
+            glBindTexture(GL_TEXTURE_2D, soundSourceTexture->GetTextureID());
+            
+            for (SoundSource* soundSource : scene.GetComponents<SoundSource>())
+                RenderEditorEntity(soundSource);
+        }
         
         // Render particle emitters.
-        glBindTexture(GL_TEXTURE_2D, particleEmitterTexture->GetTextureID());
-        
-        for (ParticleEmitter* emitter : scene.GetComponents<ParticleEmitter>())
-            RenderEditorEntity(emitter);
+        if (particleEmitters) {
+            glBindTexture(GL_TEXTURE_2D, particleEmitterTexture->GetTextureID());
+            
+            for (ParticleEmitter* emitter : scene.GetComponents<ParticleEmitter>())
+                RenderEditorEntity(emitter);
+        }
         
         // Render light sources.
-        glBindTexture(GL_TEXTURE_2D, lightTexture->GetTextureID());
-        
-        for (DirectionalLight* light : scene.GetComponents<DirectionalLight>())
-            RenderEditorEntity(light);
-        
-        for (PointLight* light : scene.GetComponents<PointLight>())
-            RenderEditorEntity(light);
-        
-        for (SpotLight* light : scene.GetComponents<SpotLight>())
-            RenderEditorEntity(light);
+        if (lightSources) {
+            glBindTexture(GL_TEXTURE_2D, lightTexture->GetTextureID());
+            
+            for (DirectionalLight* light : scene.GetComponents<DirectionalLight>())
+                RenderEditorEntity(light);
+            
+            for (PointLight* light : scene.GetComponents<PointLight>())
+                RenderEditorEntity(light);
+            
+            for (SpotLight* light : scene.GetComponents<SpotLight>())
+                RenderEditorEntity(light);
+        }
         
         glDepthMask(GL_TRUE);
         glDisable(GL_BLEND);

--- a/src/Engine/Manager/RenderManager.hpp
+++ b/src/Engine/Manager/RenderManager.hpp
@@ -33,9 +33,12 @@ class RenderManager {
         /// Render editor entities.
         /**
          * @param scene Scene to render.
+         * @param soundSources Whether to show sound sources.
+         * @param particleEmitters Whether to show particle emitters.
+         * @param lightSources Whether to show light sources.
          */
-        void RenderEditorEntities(Scene& scene);
-    
+        void RenderEditorEntities(Scene& scene, bool soundSources = true, bool particleEmitters = true, bool lightSources = true);
+        
     private:
         RenderManager();
         ~RenderManager();


### PR DESCRIPTION
Options for whether to show icons for sound sources, particle emitters and light sources in the editor.