### PR TITLE
Use AppVeyor to check Windows builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 # Hymn to Beauty
+[![AppVeyor CI Build Status](https://ci.appveyor.com/api/projects/status/ol462v1vrb3dse2v?svg=true)](https://ci.appveyor.com/project/Chainsawkitten/hymntobeauty)
+
 C++/OpenGL 3D Engine
 
 ## Building

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,17 @@
+version: '{build}'
+
+skip_tags: true
+
+configuration: Release
+
+platform: x64
+
+install:
+- cmd: git submodule update --init
+
+before_build:
+- cmd: cmake -G "Visual Studio 14 2015 Win64"
+
+build:
+  project: HymnToBeauty.sln
+  verbosity: minimal


### PR DESCRIPTION
Use AppVeyor for automatic build checking on Windows (Visual Studio 2015).