### PR TITLE
Always clear back buffer

### DIFF
--- a/src/Engine/Manager/RenderManager.cpp
+++ b/src/Engine/Manager/RenderManager.cpp
@@ -120,6 +120,8 @@ RenderManager::~RenderManager() {
 }
 
 void RenderManager::Render(World& world) {
+    glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
+    
     // Find camera entity.
     Entity* camera = nullptr;
     std::vector<Lens*> lenses = world.GetComponents<Lens>();


### PR DESCRIPTION
Removes the flickering problem when not having a scene with a camera
open.