### PR TITLE
Register script math

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -219,6 +219,7 @@ include_directories(src)
 ## Engine ##
 set(ENGINE_SRCS
         externals/AngelScript/sdk/add_on/scriptbuilder/scriptbuilder.cpp
+        externals/AngelScript/sdk/add_on/scriptmath/scriptmath.cpp
         externals/AngelScript/sdk/add_on/scriptstdstring/scriptstdstring.cpp
         externals/AngelScript/sdk/add_on/scriptstdstring/scriptstdstring_utils.cpp
         externals/imgui/imgui.cpp

--- a/src/Engine/Manager/ScriptManager.cpp
+++ b/src/Engine/Manager/ScriptManager.cpp
@@ -2,6 +2,7 @@
 
 #include <angelscript.h>
 #include <scriptbuilder/scriptbuilder.h>
+#include <scriptmath/scriptmath.h>
 #include <scriptstdstring/scriptstdstring.h>
 #include "../Util/Log.hpp"
 #include "../Util/FileSystem.hpp"
@@ -51,6 +52,7 @@ ScriptManager::ScriptManager() {
     
     // Register add-ons.
     RegisterStdString(engine);
+    RegisterScriptMath(engine);
     
     engine->RegisterEnum("input");
     


### PR DESCRIPTION
Use AngelScript's script math add-on to add sin, cos, sqrt, etc. functions to scripting language.