### PR TITLE
Fix wrong scene being overwritten

### DIFF
--- a/src/Editor/GUI/Editors/SceneEditor.cpp
+++ b/src/Editor/GUI/Editors/SceneEditor.cpp
@@ -21,10 +21,12 @@ void SceneEditor::Show() {
 
 void SceneEditor::SetScene(std::size_t sceneIndex) {
     entityEditor.SetVisible(false);
+    this->sceneIndex = sceneIndex;
     
     if (sceneIndex < Hymn().scenes.size()) {
-        this->sceneIndex = sceneIndex;
         strcpy(name, Hymn().scenes[sceneIndex].c_str());
+    } else {
+        SetVisible(false);
     }
 }
 


### PR DESCRIPTION
Fix bug where the wrong scene would be overwritten when starting and
then quitting the editor without opening the scene editor.