### PR TITLE
Revamp profiling

### DIFF
--- a/src/Editor/Editor.cpp
+++ b/src/Editor/Editor.cpp
@@ -163,6 +163,10 @@ void Editor::Show(float deltaTime) {
         if (settingsWindow.IsVisible())
             settingsWindow.Show();
 
+        // Show profiling window.
+        if (profilingWindow.IsVisible())
+            profilingWindow.Show();
+
         // Show grid settings window.
         ShowGridSettings();
         CreateGrid(gridSettings.gridSize);
@@ -409,7 +413,17 @@ void Editor::ShowMainMenuBar(bool& play) {
 
                 ImGui::EndMenu();
             }
+        }
 
+        // Debug menu.
+        if (ImGui::BeginMenu("Debug")) {
+            if (ImGui::MenuItem("Profiling"))
+                profilingWindow.SetVisible(true);
+
+            ImGui::EndMenu();
+        }
+
+        if (Hymn().GetPath() != "") {
             if (Input()->Triggered(InputHandler::ZOOM)) {
                 if (resourceView.GetScene().entityEditor.GetEntity() != nullptr) {
                     const glm::vec3 tempPos = resourceView.GetScene().entityEditor.GetEntity()->GetWorldPosition();

--- a/src/Editor/Editor.hpp
+++ b/src/Editor/Editor.hpp
@@ -6,6 +6,7 @@
 #include "GUI/SettingsWindow.hpp"
 #include "GUI/FiltersWindow.hpp"
 #include "GUI/SavePromptWindow.hpp"
+#include "GUI/ProfilingWindow.hpp"
 #include "GUI/LogView.hpp"
 #include <Engine/Entity/World.hpp>
 #include <Engine/Util/MousePicking.hpp>
@@ -120,6 +121,7 @@ class Editor {
     GUI::SettingsWindow settingsWindow;
     GUI::FiltersWindow filtersWindow;
     GUI::SavePromptWindow savePromptWindow;
+    GUI::ProfilingWindow profilingWindow;
 
     bool close;
     bool savePromptAnswered;

--- a/src/Editor/GUI/ProfilingWindow.cpp
+++ b/src/Editor/GUI/ProfilingWindow.cpp
@@ -2,19 +2,20 @@
 
 #include <Engine/Manager/Managers.hpp>
 #include <Engine/Manager/RenderManager.hpp>
+#include <Engine/Util/FileSystem.hpp>
 #include <imgui.h>
+#include <imgui_internal.h>
 #include <Utility/Log.hpp>
+#include <fstream>
+#include <limits>
+#include <algorithm>
+#include <cstring>
 
 using namespace GUI;
 
 void ProfilingWindow::Show() {
-    if (!Managers().profilingManager->Active()) {
-        Log() << "ProfilingManager::ShowResults warning: Not active.\n";
-        return;
-    }
-
     // Show the results.
-    ImGui::Begin("Profiling", nullptr);
+    ImGui::Begin("Profiling", &visible);
 
     // Frametimes.
     unsigned int frames = Managers().profilingManager->GetFrameCount();
@@ -25,58 +26,251 @@ void ProfilingWindow::Show() {
         }
     }
 
-    // Breakdown.
-    if (ImGui::CollapsingHeader("Breakdown")) {
-        for (int i = 0; i < ProfilingManager::COUNT; ++i) {
-            ProfilingManager::Result* result = Managers().profilingManager->GetResult((ProfilingManager::Type)i);
-            int flags = result->children.empty() ? ImGuiTreeNodeFlags_Leaf : 0;
-            if (ImGui::TreeNodeEx(ProfilingManager::TypeToString((ProfilingManager::Type)i).c_str(), flags)) {
-                ImGui::Columns(2);
-                for (ProfilingManager::Result& child : result->children)
-                    ShowResult(&child);
-                ImGui::Columns(1);
-                ImGui::TreePop();
-            }
-        }
-
-        ImGui::Text("Light count: %u", Managers().renderManager->GetLightCount());
+    // Timeline.
+    if (ImGui::CollapsingHeader("Timeline")) {
+        ShowTimeline();
     }
 
-    /// Update log whether or not we're actually showing it.
+    // Update log whether or not we're actually showing it.
     logView.UpdateLog();
     if (ImGui::CollapsingHeader("Log"))
         logView.Show();
 
     ImGui::End();
+
+    if (fileSelector.IsVisible())
+        fileSelector.Show();
 }
 
-void ProfilingWindow::ShowResult(ProfilingManager::Result* result) {
-    ImGui::AlignTextToFramePadding();
-    int flags = result->children.empty() ? ImGuiTreeNodeFlags_Leaf : 0;
-    bool expanded = ImGui::TreeNodeEx(result->name.c_str(), flags);
+bool ProfilingWindow::IsVisible() const {
+    return visible;
+}
 
-    ImGui::NextColumn();
-    if (result->parent->parent != nullptr) {
-        ImGui::ProgressBar(static_cast<float>(result->value / result->parent->value), ImVec2(0.0f, 0.0f));
-        ImGui::SameLine(0.0f, ImGui::GetStyle().ItemInnerSpacing.x);
+void ProfilingWindow::SetVisible(bool visible) {
+    this->visible = visible;
+}
+
+void ProfilingWindow::LoadLatest() {
+    std::string filename = "";
+
+    // Find latest profiling timeline.
+    std::vector<std::string> timelines = FileSystem::DirectoryContents(FileSystem::DataPath("Hymn to Beauty", "Profiling"), FileSystem::FILE);
+    for (const std::string& file : timelines) {
+        if (FileSystem::GetExtension(file) == "json") {
+            if (filename.empty() || strcmp(file.c_str(), filename.c_str()) > 0)
+                filename = file;
+        }
     }
 
-    ImGui::Text(std::to_string(result->value).c_str());
-    ImGui::NextColumn();
+    // Load timeline.
+    if (!filename.empty())
+        FileSelected(FileSystem::DataPath("Hymn to Beauty", "Profiling/") + filename);
+}
 
-    if (expanded) {
-        double otherTime = result->value;
-        for (ProfilingManager::Result& child : result->children) {
-            ShowResult(&child);
-            otherTime -= child.value;
+void ProfilingWindow::FileSelected(const std::string& filename) {
+    Json::Value root;
+    std::ifstream file(filename);
+    file >> root;
+    file.close();
+
+    timeline.FromJson(root);
+    ParseTimeline();
+}
+
+void ProfilingWindow::ParseTimeline() {
+    threadViews.clear();
+    earliestTime = std::numeric_limits<double>::max();
+
+    for (const Profiling::Thread& thread : timeline.threads) {
+        ThreadView threadView;
+        threadView.name = thread.name;
+        threadView.lines = 0;
+
+        for (const Profiling::Event& event : thread.events) {
+            ParseEvent(threadView, event, 0);
         }
 
-        if (!result->children.empty()) {
-            ProfilingManager::Result other("Other", result);
-            other.value = otherTime;
-            ShowResult(&other);
+        threadViews.push_back(threadView);
+    }
+
+    scale = 100.0f;
+    resetScroll = true;
+}
+
+void ProfilingWindow::ParseEvent(ThreadView& threadView, const Profiling::Event& event, unsigned int line) {
+    // Add line if we've reached a new depth.
+    if (line >= threadView.lines) {
+        threadView.events.push_back(std::vector<Profiling::Event>());
+        threadView.lines++;
+    }
+
+    // Add this event.
+    threadView.events[line].push_back(event);
+    if (event.time < earliestTime)
+        earliestTime = event.time;
+
+    // Parse children.
+    for (const Profiling::Event& child : event.children) {
+        ParseEvent(threadView, child, line + 1);
+    }
+}
+
+void ProfilingWindow::ShowTimeline() {
+    if (ImGui::Button("Load latest")) {
+        LoadLatest();
+    }
+
+    ImGui::SameLine();
+
+    if (ImGui::Button("Load JSON")) {
+        fileSelector.AddExtensions("json");
+        fileSelector.SetInitialPath(FileSystem::DataPath("Hymn to Beauty", "Profiling").c_str());
+        fileSelector.SetFileSelectedCallback(std::bind(&ProfilingWindow::FileSelected, this, std::placeholders::_1));
+        fileSelector.SetVisible(true);
+    }
+
+    // Scale slider.
+    ImGui::SameLine();
+    const float oldScale = scale;
+    const float minScale = 100.0f;
+    const float maxScale = 10000.0f;
+    ImGui::SliderFloat("Zoom", &scale, minScale, maxScale, "%.0f%%");
+    pixelsPerSecond = 100.0f * oldScale;
+
+    // Mouse zoom.
+    ImGuiIO& io = ImGui::GetIO();
+    if (io.KeyCtrl && io.MouseWheel != 0.0f) {
+        scale += io.MouseWheel * 100.0f;
+        scale = std::min(std::max(scale, minScale), maxScale);
+    }
+
+    unsigned int totalLines = 0;
+    for (const ThreadView& threadView : threadViews) {
+        totalLines += threadView.lines;
+    }
+
+    ImGui::PushStyleVar(ImGuiStyleVar_FrameRounding, 0.0f);
+    ImGui::PushStyleVar(ImGuiStyleVar_ItemSpacing, ImVec2(0.0f, 0.0f));
+    ImGui::PushStyleVar(ImGuiStyleVar_ButtonTextAlign, ImVec2(0.0f, 0.5f));
+
+    // Thread names.
+    ImGui::BeginChild("Thread names", ImVec2(100, totalLines *  ImGui::GetFrameHeightWithSpacing() + 30.0f + rulerHeight), false);
+    ShowThreadNames();
+    ImGui::EndChild();
+
+    // Timeline.
+    ImGui::SameLine();
+    ImGui::BeginChild("Timeline", ImVec2(0, totalLines *  ImGui::GetFrameHeightWithSpacing() + 30.0f + rulerHeight), true, ImGuiWindowFlags_HorizontalScrollbar);
+
+    if (scale != oldScale) {
+        // Adjust scroll position so it remains at the same time.
+        ImGui::SetScrollX(ImGui::GetScrollX() / oldScale * scale);
+    }
+
+    if (resetScroll) {
+        ImGui::SetScrollX(0.0f);
+        resetScroll = false;
+    }
+
+    // Mouse dragging.
+    ImGuiContext& context = *ImGui::GetCurrentContext();
+    if (context.HoveredId == 0) {
+        bool hovered = false;
+        bool held = false;
+
+        ImGui::ButtonBehavior(context.CurrentWindow->Rect(), ImGui::GetID("##scrolldraggingoverlay"), &hovered, &held, ImGuiMouseButton_Left);
+        const ImVec2 delta = io.MouseDelta;
+        if (held && delta.x != 0.0f)
+            ImGui::SetScrollX(ImGui::GetScrollX() - delta.x);
+    }
+
+    ShowRuler();
+
+    // Timeline events.
+    ShowThreads();
+
+    ImGui::PopStyleVar(3);
+
+    ImGui::EndChild();
+}
+
+void ProfilingWindow::ShowRuler() {
+    ImDrawList* drawList = ImGui::GetWindowDrawList();
+    const ImU32 color = ImGui::GetColorU32(ImGuiCol_Text);
+    ImGui::SetCursorPos(ImVec2(0.0f, 0.0f));
+    const ImVec2 cursorPos = ImGui::GetCursorScreenPos();
+    const double beginTime = ImGui::GetScrollX() / pixelsPerSecond;
+    const double endTime = (ImGui::GetScrollX() + ImGui::GetWindowWidth()) / pixelsPerSecond;
+    const float minPixelsPerRule = 100.0f;
+    const double step1 = minPixelsPerRule / pixelsPerSecond;
+    double step = pow(10.0, ceil(log10(step1)));
+    step = (step1 < step * 0.5) ? step * 0.5 : step;
+    step = (step1 < step * 0.5) ? step * 0.5 : step;
+
+    for (double time = beginTime - fmod(beginTime, step); time < endTime; time += step) {
+        ImVec2 position = ImVec2(cursorPos.x + time * pixelsPerSecond, cursorPos.y);
+        drawList->AddRectFilled(position, ImVec2(position.x + 1.0f, position.y + rulerHeight), color);
+        if (position.x - cursorPos.x + minPixelsPerRule < ImGui::GetScrollX() + ImGui::GetWindowWidth()) {
+            ImGui::SetCursorScreenPos(ImVec2(position.x + 2.0f, position.y));
+            ImGui::Text("%.2f ms", time * 1000.0);
+        }
+    }
+
+    for (double time = beginTime - fmod(beginTime, step); time < endTime; time += step * 0.1) {
+        ImVec2 position = ImVec2(cursorPos.x + time * pixelsPerSecond, cursorPos.y);
+        drawList->AddRectFilled(ImVec2(position.x, position.y + rulerHeight * 0.75f), ImVec2(position.x + 1.0f, position.y + rulerHeight), color);
+    }
+}
+
+void ProfilingWindow::ShowThreadNames() {
+    ImGui::SetCursorPosY(rulerHeight);
+    ImGui::Separator();
+
+    unsigned int lines = 0;
+
+    for (const ThreadView& threadView : threadViews) {
+        ImGui::SetCursorPosY(rulerHeight + lines * ImGui::GetFrameHeightWithSpacing());
+        ImGui::Text(threadView.name.c_str());
+
+        lines += threadView.lines;
+        ImGui::SetCursorPosY(rulerHeight + lines * ImGui::GetFrameHeightWithSpacing());
+
+        ImGui::Separator();
+    }
+}
+
+void ProfilingWindow::ShowThreads() {
+    ImGui::SetCursorPosY(rulerHeight);
+    ImGui::Separator();
+
+    unsigned int lines = 0;
+
+    for (const ThreadView& threadView : threadViews) {
+        for (unsigned int line = 0; line < threadView.lines; line++) {
+            for (std::size_t i = 0; i < threadView.events[line].size(); i++) {
+                if (i > 0)
+                    ImGui::SameLine();
+
+                ImGui::PushID(i + line * 10000);
+
+                const Profiling::Event& event = threadView.events[line][i];
+                ImGui::SetCursorPosX(static_cast<float>((event.time - earliestTime) * pixelsPerSecond));
+                ImGui::SetCursorPosY(rulerHeight + (lines + line) * ImGui::GetFrameHeightWithSpacing());
+                ImGui::Button(event.name.c_str(), ImVec2(std::max(static_cast<float>(event.duration * pixelsPerSecond), 1.0f), 0.0f));
+
+                if (ImGui::IsItemHovered()) {
+                    ImGui::BeginTooltip();
+                    ImGui::Text("%s - %f ms", event.name.c_str(), event.duration * 1000.0f);
+                    ImGui::EndTooltip();
+                }
+
+                ImGui::PopID();
+            }
         }
 
-        ImGui::TreePop();
+        lines += threadView.lines;
+        ImGui::SetCursorPosY(rulerHeight + lines * ImGui::GetFrameHeightWithSpacing());
+
+        ImGui::Separator();
     }
 }

--- a/src/Editor/GUI/ProfilingWindow.hpp
+++ b/src/Editor/GUI/ProfilingWindow.hpp
@@ -2,6 +2,7 @@
 
 #include <Engine/Manager/ProfilingManager.hpp>
 #include <GUI/LogView.hpp>
+#include "FileSelector.hpp"
 
 namespace GUI {
 class ProfilingWindow {
@@ -9,8 +10,49 @@ class ProfilingWindow {
     /// Show profiling results.
     void Show();
 
+    /// Get whether the window is visible.
+    /**
+     * @return Whether the window is visible.
+     */
+    bool IsVisible() const;
+
+    /// Set whether the window should be visible.
+    /**
+     * @param visible Whether the window should be visible.
+     */
+    void SetVisible(bool visible);
+
   private:
+    struct ThreadView {
+        std::string name;
+        unsigned int lines;
+        std::vector<std::vector<Profiling::Event>> events;
+    };
+
     LogView logView;
-    void ShowResult(ProfilingManager::Result* result);
+
+    void LoadLatest();
+    void FileSelected(const std::string& filename);
+
+    void ParseTimeline();
+    void ParseEvent(ThreadView& threadView, const Profiling::Event& event, unsigned int line);
+
+    void ShowTimeline();
+    void ShowRuler();
+    void ShowThreadNames();
+    void ShowThreads();
+
+    bool visible = false;
+
+    FileSelector fileSelector;
+
+    Profiling::Timeline timeline;
+    double earliestTime;
+    float scale = 100.0f;
+    double pixelsPerSecond;
+    const float rulerHeight = 24.0f;
+    bool resetScroll = false;
+
+    std::vector<ThreadView> threadViews;
 };
 } // namespace GUI

--- a/src/Editor/ImGui/Implementation.cpp
+++ b/src/Editor/ImGui/Implementation.cpp
@@ -4,6 +4,7 @@
 #include <imgui.h>
 
 #include <Engine/Util/Input.hpp>
+#include <Engine/Util/Profiling.hpp>
 #include <Video/Renderer.hpp>
 #include <Video/LowLevelRenderer/Interface/LowLevelRenderer.hpp>
 #include <Video/LowLevelRenderer/Interface/CommandBuffer.hpp>
@@ -148,6 +149,8 @@ void NewFrame() {
 }
 
 void Render() {
+    PROFILE("Render ImGui");
+
     ImGui::Render();
     ImDrawData* draw_data = ImGui::GetDrawData();
 

--- a/src/Editor/main.cpp
+++ b/src/Editor/main.cpp
@@ -49,56 +49,38 @@ int main() {
 
     Editor* editor = new Editor(Managers().renderManager->GetRenderer()->GetLowLevelRenderer());
 
-    bool profiling = false;
-    GUI::ProfilingWindow profilingWindow;
-
     // Main loop.
     while (!engine.ShouldClose() || !editor->ReadyToClose()) {
-        Managers().profilingManager->SetActive(profiling);
-
-        // Begin new profiling frame.
-        if (Managers().profilingManager->Active())
-            Managers().profilingManager->BeginFrame();
-
-        {
-            PROFILE("Frame");
-
-            if (Input()->Triggered(InputHandler::PROFILE))
-                profiling = !profiling;
-
-            // Start new frame.
-            ImGuiImplementation::NewFrame();
-
-            // Update engine.
-            engine.configuration.paused = editor->IsVisible();
-            engine.Update();
-
-            if (editor->IsVisible()) {
-                Hymn().Render(editor->GetCamera(), EditorSettings::GetInstance().GetBool("Sound Source Icons"), EditorSettings::GetInstance().GetBool("Light Source Icons"), EditorSettings::GetInstance().GetBool("Camera Icons"), EditorSettings::GetInstance().GetBool("Physics Volumes"), EditorSettings::GetInstance().GetBool("Lighting"), EditorSettings::GetInstance().GetBool("Light Volumes"));
-
-                if (window->ShouldClose())
-                    editor->Close();
-
-                editor->Show(static_cast<float>(engine.GetDeltaTime()));
-
-                if (window->ShouldClose() && !editor->isClosing())
-                    window->CancelClose();
-            } else {
-                engine.Render();
-
-                if (Input()->Triggered(InputHandler::PLAYTEST)) {
-                    // Rollback to the editor state.
-                    editor->LoadSceneState();
-
-                    // Turn editor back on.
-                    editor->SetVisible(true);
-                }
-            }
+        if (Input()->Triggered(InputHandler::PROFILE)) {
+            Managers().profilingManager->SetActive(!Managers().profilingManager->Active());
         }
 
-        if (Managers().profilingManager->Active()) {
-            Managers().profilingManager->EndFrame();
-            profilingWindow.Show();
+        // Update engine.
+        engine.configuration.paused = editor->IsVisible();
+        engine.Update();
+
+        ImGuiImplementation::NewFrame();
+
+        if (editor->IsVisible()) {
+            Hymn().Render(editor->GetCamera(), EditorSettings::GetInstance().GetBool("Sound Source Icons"), EditorSettings::GetInstance().GetBool("Light Source Icons"), EditorSettings::GetInstance().GetBool("Camera Icons"), EditorSettings::GetInstance().GetBool("Physics Volumes"), EditorSettings::GetInstance().GetBool("Lighting"), EditorSettings::GetInstance().GetBool("Light Volumes"));
+
+            if (window->ShouldClose())
+                editor->Close();
+
+            editor->Show(static_cast<float>(engine.GetDeltaTime()));
+
+            if (window->ShouldClose() && !editor->isClosing())
+                window->CancelClose();
+        } else {
+            engine.Render();
+
+            if (Input()->Triggered(InputHandler::PLAYTEST)) {
+                // Rollback to the editor state.
+                editor->LoadSceneState();
+
+                // Turn editor back on.
+                editor->SetVisible(true);
+            }
         }
 
         ImGuiImplementation::Render();

--- a/src/Engine/Util/Profiling.cpp
+++ b/src/Engine/Util/Profiling.cpp
@@ -1,20 +1,15 @@
 #include "Profiling.hpp"
 
-#include <GLFW/glfw3.h>
 #include "../Manager/Managers.hpp"
 
-using namespace std;
-
-Profiling::Profiling(const std::string& name) {
+ProfilingScope::ProfilingScope(const std::string& name) {
     if (Managers().profilingManager->Active()) {
-        result = Managers().profilingManager->StartResult(name, ProfilingManager::Type::CPU_TIME);
-        start = glfwGetTime();
+        event = Managers().profilingManager->StartEvent(name);
     }
 }
 
-Profiling::~Profiling() {
+ProfilingScope::~ProfilingScope() {
     if (Managers().profilingManager->Active()) {
-        result->value = (glfwGetTime() - start) * 1000.0;
-        Managers().profilingManager->FinishResult(result, ProfilingManager::Type::CPU_TIME);
+        Managers().profilingManager->FinishEvent(event);
     }
 }

--- a/src/Engine/Util/Profiling.hpp
+++ b/src/Engine/Util/Profiling.hpp
@@ -4,20 +4,20 @@
 #include "../Manager/ProfilingManager.hpp"
 
 /// Run profiling.
-class Profiling {
+class ProfilingScope {
   public:
     /// Start profiling.
     /**
      * @param name Name of the segment.
      */
-    explicit Profiling(const std::string& name);
+    explicit ProfilingScope(const std::string& name);
 
     /// End profiling.
-    ~Profiling();
+    ~ProfilingScope();
 
   private:
-    ProfilingManager::Result* result;
+    Profiling::Event* event;
     double start;
 };
 
-#define PROFILE(name) Profiling __profileInstance(name)
+#define PROFILE(name) ProfilingScope __profileInstance(name)

--- a/src/Utility/CMakeLists.txt
+++ b/src/Utility/CMakeLists.txt
@@ -1,16 +1,22 @@
 set(SRCS
         Log.cpp
+        Profiling/Event.cpp
+        Profiling/Thread.cpp
+        Profiling/Timeline.cpp
     )
 
 set(HEADERS
         Queue.hpp
         LockBox.hpp
         Log.hpp
+        Profiling/Event.hpp
+        Profiling/Thread.hpp
+        Profiling/Timeline.hpp
     )
 
 create_directory_groups(${SRCS} ${HEADERS})
 
 add_library(Utility STATIC ${SRCS} ${HEADERS})
-target_link_libraries(Utility glm)
+target_link_libraries(Utility glm jsoncpp_lib_static)
 set_property(TARGET Utility PROPERTY CXX_STANDARD 11)
 set_property(TARGET Utility PROPERTY CXX_STANDARD_REQUIRED ON)

--- a/src/Utility/Log.cpp
+++ b/src/Utility/Log.cpp
@@ -77,7 +77,7 @@ Log& Log::operator<<(const time_t value) {
 
     char buffer[bufferLength] = {'\0'};
     strftime(buffer, bufferLength, "%Y-%m-%d %H:%M:%S", timeinfo);
-    string const outString = string(buffer, bufferLength);
+    string const outString = string(buffer);
 
     *streams[currentChannel] << outString;
 #ifdef USINGDOUBLELOGGING

--- a/src/Utility/Profiling/Event.cpp
+++ b/src/Utility/Profiling/Event.cpp
@@ -1,0 +1,44 @@
+#include "Event.hpp"
+
+namespace Profiling {
+
+Event::Event(const std::string& name) {
+    this->name = name;
+}
+
+Json::Value Event::ToJson() const {
+    Json::Value value;
+
+    value["name"] = name;
+    value["time"] = time;
+    value["duration"] = duration;
+
+    Json::Value childrenJson;
+    for (const Event& event : children) {
+        childrenJson.append(event.ToJson());
+    }
+
+    value["children"] = childrenJson;
+
+    return value;
+}
+
+void Event::FromJson(const Json::Value& value) {
+    FromJson(value, nullptr);
+}
+
+void Event::FromJson(const Json::Value& value, Event* parent) {
+    this->parent = parent;
+    name = value["name"].asString();
+    time = value["time"].asDouble();
+    duration = value["duration"].asDouble();
+
+    const Json::Value& childrenJson = value["children"];
+    for (Json::ArrayIndex i = 0; i < childrenJson.size(); i++) {
+        children.push_back(Event(""));
+        Event* event = &children.back();
+        event->FromJson(childrenJson[i], this);
+    }
+}
+
+}

--- a/src/Utility/Profiling/Event.hpp
+++ b/src/Utility/Profiling/Event.hpp
@@ -1,0 +1,49 @@
+#pragma once
+
+#include <string>
+#include <list>
+#include <json/json.h>
+
+namespace Profiling {
+
+/// A profiling event on the timeline.
+class Event {
+  public:
+    /// Create new event.
+    /**
+     * @param name The name of the event.
+     */
+    explicit Event(const std::string& name);
+
+    /// Save event to json value.
+    /**
+     * @return Json representation of the event.
+     */
+    Json::Value ToJson() const;
+
+    /// Load event from json value.
+    /**
+     * @param value The json value to load from.
+     */
+    void FromJson(const Json::Value& value);
+
+    /// The name of the event.
+    std::string name;
+
+    /// The time the event occured.
+    double time;
+
+    /// The duration of the event.
+    double duration;
+
+    /// Child events.
+    std::list<Event> children;
+
+    /// Parent event.
+    Event* parent = nullptr;
+
+  private:
+      void FromJson(const Json::Value& value, Event* parent);
+};
+
+}

--- a/src/Utility/Profiling/Thread.cpp
+++ b/src/Utility/Profiling/Thread.cpp
@@ -1,0 +1,39 @@
+#include "Thread.hpp"
+
+namespace Profiling {
+
+Thread::Thread(const std::string& name) {
+    this->name = name;
+}
+
+Event* Thread::AddEvent(const std::string& name) {
+    events.push_back(Event(name));
+    return &events.back();
+}
+
+Json::Value Thread::ToJson() const {
+    Json::Value value;
+
+    value["name"] = name;
+
+    Json::Value eventsJson;
+    for (const Event& event : events) {
+        eventsJson.append(event.ToJson());
+    }
+
+    value["events"] = eventsJson;
+
+    return value;
+}
+
+void Thread::FromJson(const Json::Value& value) {
+    name = value["name"].asString();
+
+    const Json::Value& eventsJson = value["events"];
+    for (Json::ArrayIndex i = 0; i < eventsJson.size(); i++) {
+        Event* event = AddEvent("");
+        event->FromJson(eventsJson[i]);
+    }
+}
+
+}

--- a/src/Utility/Profiling/Thread.hpp
+++ b/src/Utility/Profiling/Thread.hpp
@@ -1,0 +1,47 @@
+#pragma once
+
+#include <string>
+#include <list>
+#include <json/json.h>
+
+#include "Event.hpp"
+
+namespace Profiling {
+
+/// A thread containing events.
+class Thread {
+  public:
+    /// Create new thread.
+    /**
+     * @param name The name of the new thread.
+     */
+    explicit Thread(const std::string& name);
+
+    /// Create new event.
+    /**
+     * @param name The name of the event.
+     *
+     * @return The event.
+     */
+    Event* AddEvent(const std::string& name);
+
+    /// Save thread to json value.
+    /**
+     * @return Json representation of the thread.
+     */
+    Json::Value ToJson() const;
+
+    /// Load thread from json value.
+    /**
+     * @param value The json value to load from.
+     */
+    void FromJson(const Json::Value& value);
+
+    /// The name of the thread.
+    std::string name;
+
+    /// Events.
+    std::list<Event> events;
+};
+
+}

--- a/src/Utility/Profiling/Timeline.cpp
+++ b/src/Utility/Profiling/Timeline.cpp
@@ -1,0 +1,37 @@
+#include "Timeline.hpp"
+
+namespace Profiling {
+
+Thread* Timeline::AddThread(const std::string& name) {
+    threads.push_back(Thread(name));
+    return &threads.back();
+}
+
+Json::Value Timeline::ToJson() const {
+    Json::Value value;
+
+    Json::Value threadsJson;
+    for (const Thread& thread : threads) {
+        threadsJson.append(thread.ToJson());
+    }
+
+    value["threads"] = threadsJson;
+
+    return value;
+}
+
+void Timeline::FromJson(const Json::Value& value) {
+    Clear();
+
+    const Json::Value& threadsJson = value["threads"];
+    for (Json::ArrayIndex i = 0; i < threadsJson.size(); i++) {
+        Thread* thread = AddThread("");
+        thread->FromJson(threadsJson[i]);
+    }
+}
+
+void Timeline::Clear() {
+    threads.clear();
+}
+
+}

--- a/src/Utility/Profiling/Timeline.hpp
+++ b/src/Utility/Profiling/Timeline.hpp
@@ -1,0 +1,41 @@
+#pragma once
+
+#include <string>
+#include <list>
+#include <json/json.h>
+
+#include "Thread.hpp"
+
+namespace Profiling {
+
+/// A timeline.
+class Timeline {
+  public:
+    /// Add a thread to the timeline.
+    /**
+     * @param name The name of the thread to add.
+     *
+     * @return The thread.
+     */
+    Thread* AddThread(const std::string& name);
+
+    /// Threads.
+    std::list<Thread> threads;
+
+    /// Save timeline to json value.
+    /**
+     * @return Json representation of the timeline.
+     */
+    Json::Value ToJson() const;
+
+    /// Load timeline from json value.
+    /**
+     * @param value The json value to load from.
+     */
+    void FromJson(const Json::Value& value);
+
+  private:
+    void Clear();
+};
+
+}

--- a/src/Video/LowLevelRenderer/Interface/CommandBuffer.hpp
+++ b/src/Video/LowLevelRenderer/Interface/CommandBuffer.hpp
@@ -27,7 +27,7 @@ class CommandBuffer {
     /**
      * @param renderPass The render pass to begin.
      */
-    virtual void BeginRenderPass(RenderPass* renderPass) = 0;
+    virtual void BeginRenderPass(RenderPass* renderPass, const std::string& name = "Untitled render pass") = 0;
 
     /// End render pass.
     virtual void EndRenderPass() = 0;

--- a/src/Video/LowLevelRenderer/Interface/LowLevelRenderer.hpp
+++ b/src/Video/LowLevelRenderer/Interface/LowLevelRenderer.hpp
@@ -11,6 +11,7 @@
 #include <glm/glm.hpp>
 #include <initializer_list>
 #include <vector>
+#include <Utility/Profiling/Event.hpp>
 
 struct ShaderSource;
 
@@ -142,8 +143,32 @@ class LowLevelRenderer {
      */
     virtual char* ReadImage(RenderPass* renderPass) = 0;
 
+    /// Set whether to profile.
+    /**
+     * @param profiling Whether to profile.
+     */
+    void SetProfiling(bool profiling) {
+        this->profiling = profiling;
+    }
+
+    /// Get whether profiling is active.
+    /**
+     * @return Whether profiling is active.
+     */
+    bool IsProfiling() const {
+        return profiling;
+    }
+
+    /// Get profiling timeline.
+    /**
+     * @return A list of events that have occurred since the last time fetching the timeline.
+     */
+    virtual const std::vector<Profiling::Event>& GetTimeline() const = 0;
+
   private:
     LowLevelRenderer(const LowLevelRenderer& other) = delete;
+
+    bool profiling = false;
 };
 
 } // namespace Video

--- a/src/Video/LowLevelRenderer/OpenGL/OpenGLCommandBuffer.hpp
+++ b/src/Video/LowLevelRenderer/OpenGL/OpenGLCommandBuffer.hpp
@@ -13,16 +13,28 @@ class OpenGLShaderProgram;
 /// OpenGL implementation of CommandBuffer.
 class OpenGLCommandBuffer : public CommandBuffer {
   public:
+    /// Timing for a block of work.
+    struct Timing {
+        /// The name of the block of work.
+        std::string name;
+
+        /// The timestamp for starting the block of work.
+        GLuint startQuery;
+
+        /// The timestamp for ending the block of work.
+        GLuint endQuery;
+    };
+
     /// Create new OpenGL command buffer.
     /**
      * @param openGLRenderer The OpenGL renderer.
      */
-    explicit OpenGLCommandBuffer(const OpenGLRenderer& openGLRenderer);
+    explicit OpenGLCommandBuffer(OpenGLRenderer& openGLRenderer);
 
     /// Destructor.
     ~OpenGLCommandBuffer() final;
 
-    void BeginRenderPass(RenderPass* renderPass) final;
+    void BeginRenderPass(RenderPass* renderPass, const std::string& name) final;
     void EndRenderPass() final;
     void BindGraphicsPipeline(GraphicsPipeline* graphicsPipeline) final;
     void SetViewport(const glm::uvec2& origin, const glm::uvec2& size) final;
@@ -40,12 +52,19 @@ class OpenGLCommandBuffer : public CommandBuffer {
     /// Submit the commands in the command buffer to the GPU.
     void Submit();
 
+    /// Get the all timings in the command buffer.
+    /**
+     * @return All recorded timings.
+     */
+    const std::vector<Timing>& GetTimings() const;
+
   private:
     OpenGLCommandBuffer(const OpenGLCommandBuffer& other) = delete;
 
     struct BeginRenderPassCommand {
         GLuint frameBuffer;
         GLbitfield clearMask;
+        unsigned int timingIndex;
     };
 
     struct BindGraphicsPipelineCommand {
@@ -205,6 +224,8 @@ class OpenGLCommandBuffer : public CommandBuffer {
     void AddCommand(const Command& command);
     void SubmitCommand(const Command& command);
 
+    OpenGLRenderer& openGLRenderer;
+
     std::vector<Command> commands;
     GLenum primitiveType;
     GLenum indexType;
@@ -216,6 +237,9 @@ class OpenGLCommandBuffer : public CommandBuffer {
     const OpenGLShaderProgram* currentShaderProgram = nullptr;
 
     const OpenGLShaderProgram* blitShaderProgram;
+
+    std::vector<Timing> timings;
+    unsigned int timingIndex;
 };
 
 } // namespace Video

--- a/src/Video/LowLevelRenderer/Vulkan/VulkanCommandBuffer.hpp
+++ b/src/Video/LowLevelRenderer/Vulkan/VulkanCommandBuffer.hpp
@@ -15,6 +15,18 @@ class VulkanTexture;
 /// Vulkan implementation of CommandBuffer.
 class VulkanCommandBuffer : public CommandBuffer {
   public:
+    /// Timing for a block of work.
+    struct Timing {
+        /// Name of the block of work.
+        std::string name;
+
+        /// The timestamp at the start of the block of work.
+        uint32_t startQuery;
+
+        /// The timestamp at the end of the block of work.
+        uint32_t endQuery;
+    };
+
     /// Create new Vulkan command buffer.
     /**
      * @param vulkanRenderer The Vulkan renderer.
@@ -26,7 +38,7 @@ class VulkanCommandBuffer : public CommandBuffer {
     /// Destructor.
     ~VulkanCommandBuffer() final;
 
-    void BeginRenderPass(RenderPass* renderPass) final;
+    void BeginRenderPass(RenderPass* renderPass, const std::string& name) final;
     void EndRenderPass() final;
     void BindGraphicsPipeline(GraphicsPipeline* graphicsPipeline) final;
     void SetViewport(const glm::uvec2& origin, const glm::uvec2& size) final;
@@ -59,6 +71,12 @@ class VulkanCommandBuffer : public CommandBuffer {
      */
     bool ContainsBlitToSwapChain() const;
 
+    /// Get the all timings in the command buffer.
+    /**
+     * @return All recorded timings.
+     */
+    const std::vector<Timing>& GetTimings() const;
+
   private:
     VulkanCommandBuffer(const VulkanCommandBuffer& other) = delete;
 
@@ -88,6 +106,8 @@ class VulkanCommandBuffer : public CommandBuffer {
     VulkanGraphicsPipeline* currentGraphicsPipeline = nullptr;
 
     std::map<const VulkanTexture*, VkImageLayout> renderTextureStates;
+
+    std::vector<Timing> timings;
 };
 
 } // namespace Video

--- a/src/Video/PostProcessing/PostProcessing.cpp
+++ b/src/Video/PostProcessing/PostProcessing.cpp
@@ -93,7 +93,7 @@ void PostProcessing::ApplyPostProcessing(CommandBuffer& commandBuffer, Texture* 
     bool hasFxaaPass = configuration.fxaa.enabled || configuration.dither.enabled;
 
     // Uber.
-    commandBuffer.BeginRenderPass(hasFxaaPass ? tempRenderPass : outputRenderPass);
+    commandBuffer.BeginRenderPass(hasFxaaPass ? tempRenderPass : outputRenderPass, "Uber post-processing");
     commandBuffer.BindGraphicsPipeline(uberPipeline);
     commandBuffer.SetViewportAndScissor(glm::uvec2(0, 0), screenSize);
     commandBuffer.BindUniformBuffer(ShaderProgram::BindingType::FRAGMENT_UNIFORMS, uberUniformBuffer);
@@ -104,7 +104,7 @@ void PostProcessing::ApplyPostProcessing(CommandBuffer& commandBuffer, Texture* 
     if (hasFxaaPass) {
         commandBuffer.EndRenderPass();
 
-        commandBuffer.BeginRenderPass(outputRenderPass);
+        commandBuffer.BeginRenderPass(outputRenderPass, "FXAA");
         commandBuffer.BindGraphicsPipeline(fxaaPipeline);
         commandBuffer.SetViewportAndScissor(glm::uvec2(0, 0), screenSize);
         commandBuffer.BindUniformBuffer(ShaderProgram::BindingType::FRAGMENT_UNIFORMS, fxaaUniformBuffer);

--- a/src/Video/Renderer.cpp
+++ b/src/Video/Renderer.cpp
@@ -140,12 +140,12 @@ void Renderer::BeginFrame() {
 }
 
 void Renderer::StartDepthPrePass() {
-    commandBuffer->BeginRenderPass(depthRenderPass);
+    commandBuffer->BeginRenderPass(depthRenderPass, "Depth pre-pass");
 }
 
 void Renderer::StartMainPass() {
     commandBuffer->EndRenderPass();
-    commandBuffer->BeginRenderPass(mainRenderPass);
+    commandBuffer->BeginRenderPass(mainRenderPass, "Main pass");
 }
 
 void Renderer::PrepareStaticMeshDepthRendering(const glm::mat4& viewMatrix, const glm::mat4& projectionMatrix) {


### PR DESCRIPTION
Redo the profiling system. Profiling is now captured using F2 and the results are saved to JSON. These JSON timelines can be viewed in the editor in a new timeline viewer available under Debug->Profiling.

![timeline](https://user-images.githubusercontent.com/4364549/110212906-e4e35100-7e9d-11eb-8149-7d78d9965fbf.png)

Syncing between GPU and CPU events is done by assuming the first timestamp is at submission time. This is not accurate, so timing between GPU and CPU can not be compared, only durations.