### PR TITLE
Fix graphics pipeline crash

### DIFF
--- a/src/Video/LowLevelRenderer/Vulkan/VulkanGraphicsPipeline.cpp
+++ b/src/Video/LowLevelRenderer/Vulkan/VulkanGraphicsPipeline.cpp
@@ -222,7 +222,7 @@ VulkanGraphicsPipeline::~VulkanGraphicsPipeline() {
 }
 
 VkPipeline VulkanGraphicsPipeline::GetPipeline(const VulkanRenderPass* renderPass) {
-    auto it = pipelines.find(renderPass);
+    auto it = pipelines.find(renderPass->GetCompatiblity());
     if (it != pipelines.end()) {
         // Use compatible pipeline.
         return it->second;
@@ -236,7 +236,7 @@ VkPipeline VulkanGraphicsPipeline::GetPipeline(const VulkanRenderPass* renderPas
             Log(Log::ERR) << "Failed to create graphics pipeline.\n";
         }
 
-        pipelines[renderPass] = pipeline;
+        pipelines[renderPass->GetCompatiblity()] = pipeline;
         return pipeline;
     }
 }

--- a/src/Video/LowLevelRenderer/Vulkan/VulkanGraphicsPipeline.hpp
+++ b/src/Video/LowLevelRenderer/Vulkan/VulkanGraphicsPipeline.hpp
@@ -75,20 +75,20 @@ class VulkanGraphicsPipeline : public GraphicsPipeline {
 
     // Pipeline cache.
     struct RenderPassCompare {
-        bool operator()(const VulkanRenderPass* a, const VulkanRenderPass* b) const {
-            if (a->HasColorAttachment() != b->HasColorAttachment()) {
-                return a->HasColorAttachment() < b->HasColorAttachment();
-            } else if (a->HasColorAttachment() && b->HasColorAttachment()) {
-                if (a->GetColorAttachment()->GetFormat() != b->GetColorAttachment()->GetFormat()) {
-                    return a->GetColorAttachment()->GetFormat() < b->GetColorAttachment()->GetFormat();
+        bool operator()(const VulkanRenderPass::Compatibility& a, const VulkanRenderPass::Compatibility& b) const {
+            if (a.hasColorAttachment != b.hasColorAttachment) {
+                return a.hasColorAttachment < b.hasColorAttachment;
+            } else if (a.hasColorAttachment && b.hasColorAttachment) {
+                if (a.colorAttachmentFormat != b.colorAttachmentFormat) {
+                    return a.colorAttachmentFormat < b.colorAttachmentFormat;
                 }
             }
 
-            if (a->HasDepthAttachment() != b->HasDepthAttachment()) {
-                return a->HasDepthAttachment() < b->HasDepthAttachment();
-            } else if (a->HasDepthAttachment() && b->HasDepthAttachment()) {
-                if (a->GetDepthAttachment()->GetFormat() != b->GetDepthAttachment()->GetFormat()) {
-                    return a->GetDepthAttachment()->GetFormat() < b->GetDepthAttachment()->GetFormat();
+            if (a.hasDepthAttachment != b.hasDepthAttachment) {
+                return a.hasDepthAttachment < b.hasDepthAttachment;
+            } else if (a.hasDepthAttachment && b.hasDepthAttachment) {
+                if (a.depthAttachmentFormat != b.depthAttachmentFormat) {
+                    return a.depthAttachmentFormat < b.depthAttachmentFormat;
                 }
             }
 
@@ -96,7 +96,7 @@ class VulkanGraphicsPipeline : public GraphicsPipeline {
         }
     };
 
-    std::map<const VulkanRenderPass*, VkPipeline, RenderPassCompare> pipelines;
+    std::map<VulkanRenderPass::Compatibility, VkPipeline, RenderPassCompare> pipelines;
 };
 
 }

--- a/src/Video/LowLevelRenderer/Vulkan/VulkanRenderPass.cpp
+++ b/src/Video/LowLevelRenderer/Vulkan/VulkanRenderPass.cpp
@@ -155,6 +155,15 @@ VulkanRenderPass::VulkanRenderPass(VkDevice device, Texture* colorAttachment, Re
     if (vkCreateFramebuffer(device, &framebufferCreateInfo, nullptr, &framebuffer) != VK_SUCCESS) {
         Log(Log::ERR) << "Failed to create framebuffer.\n";
     }
+
+    // Compatiblity information.
+    compatibility.hasColorAttachment = hasColorAttachment;
+    if (hasColorAttachment)
+        compatibility.colorAttachmentFormat = vulkanColorAttachment->GetFormat();
+
+    compatibility.hasDepthAttachment = hasDepthAttachment;
+    if (hasDepthAttachment)
+        compatibility.depthAttachmentFormat = vulkanDepthAttachment->GetFormat();
 }
 
 VulkanRenderPass::~VulkanRenderPass() {
@@ -192,6 +201,10 @@ VulkanTexture* VulkanRenderPass::GetDepthAttachment() const {
     assert(hasDepthAttachment);
 
     return depthAttachment;
+}
+
+const VulkanRenderPass::Compatibility& VulkanRenderPass::GetCompatiblity() const {
+    return compatibility;
 }
 
 }

--- a/src/Video/LowLevelRenderer/Vulkan/VulkanRenderPass.hpp
+++ b/src/Video/LowLevelRenderer/Vulkan/VulkanRenderPass.hpp
@@ -13,6 +13,24 @@ class VulkanTexture;
 /// Vulkan implementation of RenderPass.
 class VulkanRenderPass : public RenderPass {
   public:
+    /// Compatibility information about the render pass.
+    /**
+     * Two render passes with the same compatibility informations are compatible.
+     */
+    struct Compatibility {
+        /// Whether the render pass has a color attachment.
+        bool hasColorAttachment;
+
+        /// The format of the render pass' color attachment.
+        VkFormat colorAttachmentFormat;
+
+        /// Whether the render pass has a depth attachment.
+        bool hasDepthAttachment;
+
+        /// The format of the render pass' depth attachment.
+        VkFormat depthAttachmentFormat;
+    };
+
     /// Create new Vulkan render pass.
     /**
      * @param device The Vulkan device.
@@ -64,6 +82,12 @@ class VulkanRenderPass : public RenderPass {
      */
     VulkanTexture* GetDepthAttachment() const;
 
+    /// Get the render pass' compatibility information.
+    /**
+     * @return The compatibility information.
+     */
+    const Compatibility& GetCompatiblity() const;
+
   private:
     VulkanRenderPass(const VulkanRenderPass& other) = delete;
 
@@ -77,6 +101,7 @@ class VulkanRenderPass : public RenderPass {
     VulkanTexture* depthAttachment;
 
     glm::uvec2 size;
+    Compatibility compatibility;
 };
 
 } // namespace Video


### PR DESCRIPTION
Fix stale render pass pointer by introducing a render pass compatibility struct that stores information about render pass compatibility instead of querying the information from the render passes directly.