### PR TITLE
Optimize pipeline barriers

### DIFF
--- a/src/Video/DebugDrawing.cpp
+++ b/src/Video/DebugDrawing.cpp
@@ -369,7 +369,7 @@ void DebugDrawing::BindGraphicsPipeline(GraphicsPipeline* graphicsPipeline) {
     }
 }
 
-void DebugDrawing::BindGeometry(const GeometryBinding* geometryBinding) {
+void DebugDrawing::BindGeometry(GeometryBinding* geometryBinding) {
     if (boundGeometry != geometryBinding) {
         if (geometryBinding != nullptr) {
             CommandBuffer* commandBuffer = renderer->GetCommandBuffer();

--- a/src/Video/DebugDrawing.hpp
+++ b/src/Video/DebugDrawing.hpp
@@ -218,7 +218,7 @@ class DebugDrawing {
         unsigned int indexCount = 0;
 
         /// Geometry binding.
-        const GeometryBinding* geometryBinding = nullptr;
+        GeometryBinding* geometryBinding = nullptr;
     };
 
     /// Create new debug primitive renderer.
@@ -299,7 +299,7 @@ class DebugDrawing {
 
     void CreateVertexBuffer(const glm::vec3* positions, unsigned int positionCount, Buffer*& vertexBuffer, GeometryBinding*& geometryBinding);
     void BindGraphicsPipeline(GraphicsPipeline* graphicsPipeline);
-    void BindGeometry(const GeometryBinding* geometryBinding);
+    void BindGeometry(GeometryBinding* geometryBinding);
     void CreateCircle(glm::vec3*& positions, unsigned int& vertexCount, unsigned int detail);
     void CreateSphere(glm::vec3*& positions, unsigned int& vertexCount, unsigned int detail);
     void CreateCylinder(glm::vec3*& positions, unsigned int& vertexCount, unsigned int detail);

--- a/src/Video/Geometry/Geometry3D.cpp
+++ b/src/Video/Geometry/Geometry3D.cpp
@@ -17,7 +17,7 @@ Geometry3D::~Geometry3D() {
     delete vertexDescription;
 }
 
-const GeometryBinding* Geometry3D::GetGeometryBinding() const {
+GeometryBinding* Geometry3D::GetGeometryBinding() {
     return geometryBinding;
 }
 

--- a/src/Video/Geometry/Geometry3D.hpp
+++ b/src/Video/Geometry/Geometry3D.hpp
@@ -27,7 +27,7 @@ class Geometry3D {
     /**
      * @return The geometry binding.
      */
-    const GeometryBinding* GetGeometryBinding() const;
+    GeometryBinding* GetGeometryBinding();
 
     /// Get number of indices.
     /**

--- a/src/Video/LowLevelRenderer/Interface/CommandBuffer.hpp
+++ b/src/Video/LowLevelRenderer/Interface/CommandBuffer.hpp
@@ -16,6 +16,9 @@ class GraphicsPipeline;
 class ComputePipeline;
 
 /// A buffer into which rendering commands are recorded.
+/**
+ * Command buffers have to be recorded in the same order as they are submitted.
+ */
 class CommandBuffer {
   public:
     /// Create a new command buffer.
@@ -73,7 +76,7 @@ class CommandBuffer {
     /**
      * @param geometryBinding The geometry to bind.
      */
-    virtual void BindGeometry(const GeometryBinding* geometryBinding) = 0;
+    virtual void BindGeometry(GeometryBinding* geometryBinding) = 0;
 
     /// Bind uniform buffer for use in a shader.
     /**
@@ -92,7 +95,7 @@ class CommandBuffer {
     /**
      * @param textures The textures to bind to the graphics pipeline.
      */
-    virtual void BindMaterial(std::initializer_list<const Texture*> textures) = 0;
+    virtual void BindMaterial(std::initializer_list<Texture*> textures) = 0;
 
     /// Update push constants.
     /**

--- a/src/Video/LowLevelRenderer/Interface/LowLevelRenderer.hpp
+++ b/src/Video/LowLevelRenderer/Interface/LowLevelRenderer.hpp
@@ -78,7 +78,7 @@ class LowLevelRenderer {
      *
      * @return The created geometry binding.
      */
-    virtual GeometryBinding* CreateGeometryBinding(const VertexDescription* vertexDescription, const Buffer* vertexBuffer, GeometryBinding::IndexType indexType = GeometryBinding::IndexType::NONE, const Buffer* indexBuffer = nullptr) = 0;
+    virtual GeometryBinding* CreateGeometryBinding(const VertexDescription* vertexDescription, Buffer* vertexBuffer, GeometryBinding::IndexType indexType = GeometryBinding::IndexType::NONE, const Buffer* indexBuffer = nullptr) = 0;
 
     /// Create a shader.
     /**

--- a/src/Video/LowLevelRenderer/OpenGL/OpenGLCommandBuffer.hpp
+++ b/src/Video/LowLevelRenderer/OpenGL/OpenGLCommandBuffer.hpp
@@ -40,10 +40,10 @@ class OpenGLCommandBuffer : public CommandBuffer {
     void SetViewport(const glm::uvec2& origin, const glm::uvec2& size) final;
     void SetScissor(const glm::uvec2& origin, const glm::uvec2& size) final;
     void SetLineWidth(float width) final;
-    void BindGeometry(const GeometryBinding* geometryBinding) final;
+    void BindGeometry(GeometryBinding* geometryBinding) final;
     void BindUniformBuffer(ShaderProgram::BindingType bindingType, Buffer* uniformBuffer) final;
     void BindStorageBuffer(Buffer* storageBuffer) final;
-    void BindMaterial(std::initializer_list<const Texture*> textures) final;
+    void BindMaterial(std::initializer_list<Texture*> textures) final;
     void PushConstants(const void* data) final;
     void Draw(unsigned int vertexCount, unsigned int firstVertex) final;
     void DrawIndexed(unsigned int indexCount, unsigned int firstIndex, unsigned int baseVertex) final;
@@ -225,7 +225,8 @@ class OpenGLCommandBuffer : public CommandBuffer {
             DRAW_INDEXED,
             BLIT_TO_SWAP_CHAIN,
             BIND_COMPUTE_PIPELINE,
-            DISPATCH
+            DISPATCH,
+            MEMORY_BARRIER
         } type;
     };
 
@@ -253,6 +254,8 @@ class OpenGLCommandBuffer : public CommandBuffer {
     const OpenGLShaderProgram* currentShaderProgram = nullptr;
 
     const OpenGLShaderProgram* blitShaderProgram;
+
+    bool writesStorageBuffer = false;
 
     std::vector<Timing> timings;
     unsigned int timingIndex;

--- a/src/Video/LowLevelRenderer/OpenGL/OpenGLRenderer.cpp
+++ b/src/Video/LowLevelRenderer/OpenGL/OpenGLRenderer.cpp
@@ -140,7 +140,7 @@ VertexDescription* OpenGLRenderer::CreateVertexDescription(unsigned int attribut
     return new OpenGLVertexDescription(attributeCount, attributes, indexBuffer);
 }
 
-GeometryBinding* OpenGLRenderer::CreateGeometryBinding(const VertexDescription* vertexDescription, const Buffer* vertexBuffer, GeometryBinding::IndexType indexType, const Buffer* indexBuffer) {
+GeometryBinding* OpenGLRenderer::CreateGeometryBinding(const VertexDescription* vertexDescription, Buffer* vertexBuffer, GeometryBinding::IndexType indexType, const Buffer* indexBuffer) {
     return new OpenGLGeometryBinding(vertexDescription, vertexBuffer, indexType, indexBuffer);
 }
 

--- a/src/Video/LowLevelRenderer/OpenGL/OpenGLRenderer.hpp
+++ b/src/Video/LowLevelRenderer/OpenGL/OpenGLRenderer.hpp
@@ -29,7 +29,7 @@ class OpenGLRenderer : public LowLevelRenderer {
     void Present() final;
     Buffer* CreateBuffer(Buffer::BufferUsage bufferUsage, unsigned int size, const void* data = nullptr) final;
     VertexDescription* CreateVertexDescription(unsigned int attributeCount, const VertexDescription::Attribute* attributes, bool indexBuffer = false) final;
-    GeometryBinding* CreateGeometryBinding(const VertexDescription* vertexDescription, const Buffer* vertexBuffer, GeometryBinding::IndexType indexType = GeometryBinding::IndexType::NONE, const Buffer* indexBuffer = nullptr) final;
+    GeometryBinding* CreateGeometryBinding(const VertexDescription* vertexDescription, Buffer* vertexBuffer, GeometryBinding::IndexType indexType = GeometryBinding::IndexType::NONE, const Buffer* indexBuffer = nullptr) final;
     Shader* CreateShader(const ShaderSource& shaderSource, Shader::Type type) final;
     ShaderProgram* CreateShaderProgram(std::initializer_list<const Shader*> shaders) final;
     Texture* CreateTexture(const glm::uvec2 size, Texture::Type type, Texture::Format format, int components = 0, unsigned char* data = nullptr) final;

--- a/src/Video/LowLevelRenderer/OpenGL/OpenGLShaderProgram.cpp
+++ b/src/Video/LowLevelRenderer/OpenGL/OpenGLShaderProgram.cpp
@@ -29,13 +29,16 @@ OpenGLShaderProgram::OpenGLShaderProgram(std::initializer_list<const Shader*> sh
         Log() << std::string(infoLog.begin(), infoLog.end());
     }
 
-    // Detach shaders so that they can later be deleted.
-    for (const Shader* shader : shaders)
+    for (const Shader* shader : shaders) {
+        // Detach shaders so that they can later be deleted.
         glDetachShader(shaderProgram, static_cast<const OpenGLShader*>(shader)->GetShaderID());
 
-    // Get information about push constants.
-    for (const Shader* shader : shaders) {
-        AddPushConstants(static_cast<const OpenGLShader*>(shader)->GetReflectionInfo());
+        // Get reflection information.
+        const ShaderSource::ReflectionInfo& reflectionInfo = static_cast<const OpenGLShader*>(shader)->GetReflectionInfo();
+        AddPushConstants(reflectionInfo);
+
+        if (reflectionInfo.storageBufferReadWrite)
+            writesToStorageBuffer = true;
     }
 }
 
@@ -49,6 +52,10 @@ unsigned int OpenGLShaderProgram::GetID() const {
 
 const std::vector<OpenGLShaderProgram::PushConstant>& OpenGLShaderProgram::GetPushConstants() const {
     return pushConstants;
+}
+
+bool OpenGLShaderProgram::WritesToStorageBuffer() const {
+    return writesToStorageBuffer;
 }
 
 void OpenGLShaderProgram::AddPushConstants(const ShaderSource::ReflectionInfo& reflectionInfo) {

--- a/src/Video/LowLevelRenderer/OpenGL/OpenGLShaderProgram.hpp
+++ b/src/Video/LowLevelRenderer/OpenGL/OpenGLShaderProgram.hpp
@@ -29,7 +29,7 @@ class OpenGLShaderProgram : public ShaderProgram {
     /**
      * @param shaders List of shaders to link together.
      */
-    OpenGLShaderProgram(std::initializer_list<const Shader*> shaders);
+    explicit OpenGLShaderProgram(std::initializer_list<const Shader*> shaders);
 
     /// Destructor.
     ~OpenGLShaderProgram() final;
@@ -47,6 +47,12 @@ class OpenGLShaderProgram : public ShaderProgram {
      */
     const std::vector<PushConstant>& GetPushConstants() const;
 
+    /// Get whether the shader program writes to a storage buffer.
+    /**
+     * @return Whether the shader program writes to a storage buffer.
+     */
+    bool WritesToStorageBuffer() const;
+
   private:
     OpenGLShaderProgram(const OpenGLShaderProgram& other) = delete;
 
@@ -54,6 +60,8 @@ class OpenGLShaderProgram : public ShaderProgram {
 
     GLuint shaderProgram;
     std::vector<PushConstant> pushConstants;
+
+    bool writesToStorageBuffer = false;
 };
 
 }

--- a/src/Video/LowLevelRenderer/Vulkan/VulkanBuffer.cpp
+++ b/src/Video/LowLevelRenderer/Vulkan/VulkanBuffer.cpp
@@ -119,4 +119,24 @@ VkBuffer VulkanBuffer::GetBuffer() const {
     return buffer[currentFrame];
 }
 
+VkPipelineStageFlags VulkanBuffer::GetReadMask() const {
+    return readMask;
+}
+
+void VulkanBuffer::SetReadMaskStage(VkPipelineStageFlags pipelineStage) {
+    readMask |= pipelineStage;
+}
+
+void VulkanBuffer::ClearReadMask() {
+    readMask = 0;
+}
+
+VkPipelineStageFlags VulkanBuffer::GetLastWriteStage() const {
+    return lastWrite;
+}
+
+void VulkanBuffer::SetLastWriteStage(VkPipelineStageFlags pipelineStage) {
+    lastWrite = pipelineStage;
+}
+
 } // namespace Video

--- a/src/Video/LowLevelRenderer/Vulkan/VulkanBuffer.hpp
+++ b/src/Video/LowLevelRenderer/Vulkan/VulkanBuffer.hpp
@@ -34,6 +34,33 @@ class VulkanBuffer : public Buffer {
      */
     VkBuffer GetBuffer() const;
 
+    /// Get which pipeline stages have read the buffer since the last write.
+    /**
+     * @return A mask of all pipeline stages which have read the buffer.
+     */
+    VkPipelineStageFlags GetReadMask() const;
+
+    /// Set a pipeline stage having read the buffer since the last write.
+    /**
+     * @param pipelineStage The pipeline stage reading the buffer.
+     */
+    void SetReadMaskStage(VkPipelineStageFlags pipelineStage);
+
+    /// Clear the read mask.
+    void ClearReadMask();
+
+    /// Get the shader stage which last wrote to the buffer.
+    /**
+     * @return The last shader stage which wrote to the buffer (or 0 if none).
+     */
+    VkPipelineStageFlags GetLastWriteStage() const;
+
+    /// Set which pipeline stage last wrote to the buffer.
+    /**
+     * @param pipelineStage The pipeline stage writing to the buffer.
+     */
+    void SetLastWriteStage(VkPipelineStageFlags pipelineStage);
+
   private:
     VulkanBuffer(const VulkanBuffer& other) = delete;
 
@@ -44,6 +71,9 @@ class VulkanBuffer : public Buffer {
 
     uint32_t currentFrame = 0;
     uint32_t swapChainImages;
+
+    VkPipelineStageFlags readMask = 0;
+    VkPipelineStageFlags lastWrite = 0;
 };
 
 }

--- a/src/Video/LowLevelRenderer/Vulkan/VulkanCommandBuffer.hpp
+++ b/src/Video/LowLevelRenderer/Vulkan/VulkanCommandBuffer.hpp
@@ -2,11 +2,11 @@
 
 #include "../Interface/CommandBuffer.hpp"
 #include <vulkan/vulkan.h>
-#include <map>
 #include <vector>
 
 namespace Video {
 
+class VulkanBuffer;
 class VulkanRenderer;
 class VulkanRenderPass;
 class VulkanGraphicsPipeline;
@@ -45,10 +45,10 @@ class VulkanCommandBuffer : public CommandBuffer {
     void SetViewport(const glm::uvec2& origin, const glm::uvec2& size) final;
     void SetScissor(const glm::uvec2& origin, const glm::uvec2& size) final;
     void SetLineWidth(float width) final;
-    void BindGeometry(const GeometryBinding* geometryBinding) final;
+    void BindGeometry(GeometryBinding* geometryBinding) final;
     void BindUniformBuffer(ShaderProgram::BindingType bindingType, Buffer* uniformBuffer) final;
     void BindStorageBuffer(Buffer* storageBuffer) final;
-    void BindMaterial(std::initializer_list<const Texture*> textures) final;
+    void BindMaterial(std::initializer_list<Texture*> textures) final;
     void PushConstants(const void* data) final;
     void Draw(unsigned int vertexCount, unsigned int firstVertex) final;
     void DrawIndexed(unsigned int indexCount, unsigned int firstIndex, unsigned int baseVertex) final;
@@ -85,8 +85,8 @@ class VulkanCommandBuffer : public CommandBuffer {
 
     void Begin();
 
-    void TransitionTexture(const VulkanTexture* texture, VkImageLayout destinationImageLayout);
-    void ResetImageLayouts();
+    void TransitionTexture(VulkanTexture* texture, VkImageLayout destinationImageLayout);
+    void BufferBarrier(VulkanBuffer* buffer, VkPipelineStageFlags stages, bool write);
 
     VulkanRenderer* vulkanRenderer;
     VkDevice device;
@@ -108,8 +108,6 @@ class VulkanCommandBuffer : public CommandBuffer {
     const VulkanRenderPass* currentRenderPass = nullptr;
     VulkanGraphicsPipeline* currentGraphicsPipeline = nullptr;
     VulkanComputePipeline* currentComputePipeline = nullptr;
-
-    std::map<const VulkanTexture*, VkImageLayout> renderTextureStates;
 
     std::vector<Timing> timings;
 };

--- a/src/Video/LowLevelRenderer/Vulkan/VulkanGeometryBinding.cpp
+++ b/src/Video/LowLevelRenderer/Vulkan/VulkanGeometryBinding.cpp
@@ -6,11 +6,11 @@
 
 namespace Video {
 
-VulkanGeometryBinding::VulkanGeometryBinding(const Buffer* vertexBuffer, IndexType indexType, const Buffer* indexBuffer) {
+VulkanGeometryBinding::VulkanGeometryBinding(Buffer* vertexBuffer, IndexType indexType, const Buffer* indexBuffer) {
     assert(vertexBuffer != nullptr);
     assert(indexType == IndexType::NONE || indexBuffer != nullptr);
 
-    this->vertexBuffer = static_cast<const VulkanBuffer*>(vertexBuffer);
+    this->vertexBuffer = static_cast<VulkanBuffer*>(vertexBuffer);
     this->indexType = indexType;
     if (indexType != IndexType::NONE) {
         this->indexBuffer = static_cast<const VulkanBuffer*>(indexBuffer);
@@ -23,8 +23,8 @@ VulkanGeometryBinding::~VulkanGeometryBinding() {
 
 }
 
-VkBuffer VulkanGeometryBinding::GetVertexBuffer() const {
-    return vertexBuffer->GetBuffer();
+VulkanBuffer* VulkanGeometryBinding::GetVertexBuffer() {
+    return vertexBuffer;
 }
 
 GeometryBinding::IndexType VulkanGeometryBinding::GetIndexType() const {

--- a/src/Video/LowLevelRenderer/Vulkan/VulkanGeometryBinding.hpp
+++ b/src/Video/LowLevelRenderer/Vulkan/VulkanGeometryBinding.hpp
@@ -18,7 +18,7 @@ class VulkanGeometryBinding : public GeometryBinding {
      * @param indexType The type of values in the index buffer.
      * @param indexBuffer Index buffer.
      */
-    VulkanGeometryBinding(const Buffer* vertexBuffer, IndexType indexType = IndexType::NONE, const Buffer* indexBuffer = nullptr);
+    VulkanGeometryBinding(Buffer* vertexBuffer, IndexType indexType = IndexType::NONE, const Buffer* indexBuffer = nullptr);
 
     /// Destructor.
     ~VulkanGeometryBinding() final;
@@ -27,7 +27,7 @@ class VulkanGeometryBinding : public GeometryBinding {
     /**
      * @return The vertex buffer.
      */
-    VkBuffer GetVertexBuffer() const;
+    VulkanBuffer* GetVertexBuffer();
 
     /// Get the type of values in the index buffer.
     /**
@@ -44,7 +44,7 @@ class VulkanGeometryBinding : public GeometryBinding {
   private:
     VulkanGeometryBinding(const VulkanGeometryBinding& other) = delete;
 
-    const VulkanBuffer* vertexBuffer;
+    VulkanBuffer* vertexBuffer;
     const VulkanBuffer* indexBuffer;
     IndexType indexType;
 };

--- a/src/Video/LowLevelRenderer/Vulkan/VulkanRenderer.cpp
+++ b/src/Video/LowLevelRenderer/Vulkan/VulkanRenderer.cpp
@@ -210,7 +210,7 @@ VertexDescription* VulkanRenderer::CreateVertexDescription(unsigned int attribut
     return new VulkanVertexDescription(attributeCount, attributes);
 }
 
-GeometryBinding* VulkanRenderer::CreateGeometryBinding(const VertexDescription* vertexDescription, const Buffer* vertexBuffer, GeometryBinding::IndexType indexType, const Buffer* indexBuffer) {
+GeometryBinding* VulkanRenderer::CreateGeometryBinding(const VertexDescription* vertexDescription, Buffer* vertexBuffer, GeometryBinding::IndexType indexType, const Buffer* indexBuffer) {
     return new VulkanGeometryBinding(vertexBuffer, indexType, indexBuffer);
 }
 
@@ -394,7 +394,7 @@ VkDescriptorSet VulkanRenderer::GetDescriptorSet(ShaderProgram::BindingType bind
     }
 }
 
-VkDescriptorSet VulkanRenderer::GetDescriptorSet(std::initializer_list<const Texture*> textures) {
+VkDescriptorSet VulkanRenderer::GetDescriptorSet(std::initializer_list<Texture*> textures) {
     /// @todo Have some material object keep track of this instead of treating textures individually.
 
     VkDescriptorSetLayout descriptorSetLayout = GetMaterialDescriptorSetLayout(textures.size());

--- a/src/Video/LowLevelRenderer/Vulkan/VulkanRenderer.hpp
+++ b/src/Video/LowLevelRenderer/Vulkan/VulkanRenderer.hpp
@@ -32,7 +32,7 @@ class VulkanRenderer : public LowLevelRenderer {
     void Present() final;
     Buffer* CreateBuffer(Buffer::BufferUsage bufferUsage, unsigned int size, const void* data = nullptr) final;
     VertexDescription* CreateVertexDescription(unsigned int attributeCount, const VertexDescription::Attribute* attributes, bool indexBuffer = false) final;
-    GeometryBinding* CreateGeometryBinding(const VertexDescription* vertexDescription, const Buffer* vertexBuffer, GeometryBinding::IndexType indexType = GeometryBinding::IndexType::NONE, const Buffer* indexBuffer = nullptr) final;
+    GeometryBinding* CreateGeometryBinding(const VertexDescription* vertexDescription, Buffer* vertexBuffer, GeometryBinding::IndexType indexType = GeometryBinding::IndexType::NONE, const Buffer* indexBuffer = nullptr) final;
     Shader* CreateShader(const ShaderSource& shaderSource, Shader::Type type) final;
     ShaderProgram* CreateShaderProgram(std::initializer_list<const Shader*> shaders) final;
     Texture* CreateTexture(const glm::uvec2 size, Texture::Type type, Texture::Format format, int components = 0, unsigned char* data = nullptr) final;
@@ -89,7 +89,7 @@ class VulkanRenderer : public LowLevelRenderer {
      *
      * @return The descriptor set.
      */
-    VkDescriptorSet GetDescriptorSet(std::initializer_list<const Texture*> textures);
+    VkDescriptorSet GetDescriptorSet(std::initializer_list<Texture*> textures);
 
     /// Get whether wide lines are supported.
     /**

--- a/src/Video/LowLevelRenderer/Vulkan/VulkanShaderProgram.hpp
+++ b/src/Video/LowLevelRenderer/Vulkan/VulkanShaderProgram.hpp
@@ -44,6 +44,18 @@ class VulkanShaderProgram : public ShaderProgram {
      */
     const VkPushConstantRange* GetPushConstantRange() const;
 
+    /// Get the pipeline stages the storage buffer is used in.
+    /**
+     * @return The shader pipeline stages.
+     */
+    VkPipelineStageFlags GetStorageBufferPipelineStages() const;
+
+    /// Get whether the shader program writes to a storage buffer.
+    /**
+     * @return Whether the shader program writes to a storage buffer.
+     */
+    bool WritesToStorageBuffer() const;
+
   private:
     VulkanShaderProgram(const VulkanShaderProgram& other) = delete;
 
@@ -59,6 +71,9 @@ class VulkanShaderProgram : public ShaderProgram {
 
     bool usesPushConstants = false;
     VkPushConstantRange pushConstantRange;
+
+    VkPipelineStageFlags storageBufferPipelineStages = 0;
+    bool writesToStorageBuffer = false;
 };
 
 } // namespace Video

--- a/src/Video/LowLevelRenderer/Vulkan/VulkanTexture.cpp
+++ b/src/Video/LowLevelRenderer/Vulkan/VulkanTexture.cpp
@@ -174,12 +174,12 @@ VulkanTexture::VulkanTexture(VulkanRenderer& vulkanRenderer, VkDevice device, Vk
 
     if (type == Texture::Type::RENDER_COLOR || type == Texture::Type::RENDER_DEPTH) {
         // Transition to attachment layout.
-        VkImageLayout layout = (type == Texture::Type::RENDER_DEPTH ? VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL : VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL);
+        currentLayout = (type == Texture::Type::RENDER_DEPTH ? VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL : VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL);
 
         CommandBuffer* commandBuffer = vulkanRenderer.CreateCommandBuffer();
         VulkanCommandBuffer* vulkanCommandBuffer = static_cast<VulkanCommandBuffer*>(commandBuffer);
 
-        Utility::TransitionImage(vulkanCommandBuffer->GetCommandBuffer(), image, VK_IMAGE_LAYOUT_UNDEFINED, layout);
+        Utility::TransitionImage(vulkanCommandBuffer->GetCommandBuffer(), image, VK_IMAGE_LAYOUT_UNDEFINED, currentLayout);
 
         vulkanRenderer.Submit(commandBuffer);
         vulkanRenderer.Wait();
@@ -209,6 +209,14 @@ VkImageView VulkanTexture::GetImageView() const {
 
 VkSampler VulkanTexture::GetSampler() const {
     return sampler;
+}
+
+VkImageLayout VulkanTexture::GetImageLayout() const {
+    return currentLayout;
+}
+
+void VulkanTexture::SetImageLayout(VkImageLayout layout) {
+    currentLayout = layout;
 }
 
 void VulkanTexture::GenerateMipMaps(VulkanRenderer& vulkanRenderer, VkPhysicalDevice physicalDevice, const glm::uvec2& size, uint32_t mipLevels, VkFormat format) {

--- a/src/Video/LowLevelRenderer/Vulkan/VulkanTexture.hpp
+++ b/src/Video/LowLevelRenderer/Vulkan/VulkanTexture.hpp
@@ -52,6 +52,18 @@ class VulkanTexture : public Texture {
      */
     VkSampler GetSampler() const;
 
+    /// Get the current image layout.
+    /**
+     * @return The image layout.
+     */
+    VkImageLayout GetImageLayout() const;
+
+    /// Set the current image layout.
+    /**
+     * @param layout The new image layout.
+     */
+    void SetImageLayout(VkImageLayout layout);
+
   private:
     VulkanTexture(const VulkanTexture& other) = delete;
 
@@ -64,6 +76,7 @@ class VulkanTexture : public Texture {
     VkDeviceMemory deviceMemory;
     VkImageView imageView;
     VkSampler sampler = VK_NULL_HANDLE;
+    VkImageLayout currentLayout;
 };
 
 }

--- a/src/Video/RenderProgram/StaticRenderProgram.cpp
+++ b/src/Video/RenderProgram/StaticRenderProgram.cpp
@@ -114,7 +114,7 @@ void StaticRenderProgram::PreRender(CommandBuffer& commandBuffer, const glm::mat
     commandBuffer.BindStorageBuffer(lightBuffer);
 }
 
-void StaticRenderProgram::Render(CommandBuffer& commandBuffer, Geometry::Geometry3D* geometry, const Video::Texture2D* textureAlbedo, const Video::Texture2D* textureNormal, const Video::Texture2D* textureRoughnessMetallic, const glm::mat4& modelMatrix) const {
+void StaticRenderProgram::Render(CommandBuffer& commandBuffer, Geometry::Geometry3D* geometry, Video::Texture2D* textureAlbedo, Video::Texture2D* textureNormal, Video::Texture2D* textureRoughnessMetallic, const glm::mat4& modelMatrix) const {
     commandBuffer.BindGeometry(geometry->GetGeometryBinding());
 
     // Textures

--- a/src/Video/RenderProgram/StaticRenderProgram.hpp
+++ b/src/Video/RenderProgram/StaticRenderProgram.hpp
@@ -64,7 +64,7 @@ class StaticRenderProgram : public RenderProgram {
      * @param textureRoughnessMetallic Roughness-metallic texture.
      * @param modelMatrix Model matrix.
      */
-    void Render(CommandBuffer& commandBuffer, Geometry::Geometry3D* geometry, const Video::Texture2D* textureAlbedo, const Video::Texture2D* textureNormal, const Video::Texture2D* textureRoughnessMetallic, const glm::mat4& modelMatrix) const;
+    void Render(CommandBuffer& commandBuffer, Geometry::Geometry3D* geometry, Video::Texture2D* textureAlbedo, Video::Texture2D* textureNormal, Video::Texture2D* textureRoughnessMetallic, const glm::mat4& modelMatrix) const;
 
   private:
     StaticRenderProgram(const StaticRenderProgram& other) = delete;

--- a/src/Video/Renderer.cpp
+++ b/src/Video/Renderer.cpp
@@ -159,7 +159,7 @@ void Renderer::PrepareStaticMeshRendering(const glm::mat4& viewMatrix, const glm
     commandBuffer->SetViewportAndScissor(glm::uvec2(0, 0), renderSurfaceSize);
 }
 
-void Renderer::RenderStaticMesh(Geometry::Geometry3D* geometry, const Texture2D* albedo, const Texture2D* normal, const Texture2D* roughnessMetallic, const glm::mat4 modelMatrix) {
+void Renderer::RenderStaticMesh(Geometry::Geometry3D* geometry, Texture2D* albedo, Texture2D* normal, Texture2D* roughnessMetallic, const glm::mat4 modelMatrix) {
     staticRenderProgram->Render(*commandBuffer, geometry, albedo, normal, roughnessMetallic, modelMatrix);
 }
 
@@ -211,7 +211,7 @@ void Renderer::PrepareRenderingIcons(const glm::mat4& viewProjectionMatrix, cons
     this->cameraUp = cameraUp;
 }
 
-void Renderer::RenderIcon(const glm::vec3& position, const Texture2D* icon) {
+void Renderer::RenderIcon(const glm::vec3& position, Texture2D* icon) {
     if (currentIcon != icon) {
         currentIcon = icon;
         commandBuffer->BindMaterial({icon->GetTexture()});

--- a/src/Video/Renderer.hpp
+++ b/src/Video/Renderer.hpp
@@ -100,7 +100,7 @@ class Renderer {
      * @param roughnessMetallic Roughness-metallic texture.
      * @param modelMatrix Model matrix.
      */
-    void RenderStaticMesh(Geometry::Geometry3D* geometry, const Texture2D* albedo, const Texture2D* normal, const Texture2D* roughnessMetallic, const glm::mat4 modelMatrix);
+    void RenderStaticMesh(Geometry::Geometry3D* geometry, Texture2D* albedo, Texture2D* normal, Texture2D* roughnessMetallic, const glm::mat4 modelMatrix);
 
     /// Update light buffer.
     /**
@@ -138,7 +138,7 @@ class Renderer {
      * @param position World position to render at.
      * @param icon The icon to render.
      */
-    void RenderIcon(const glm::vec3& position, const Texture2D* icon);
+    void RenderIcon(const glm::vec3& position, Texture2D* icon);
 
     /// Configure the post-processing.
     /**

--- a/src/Video/Texture/Texture2D.cpp
+++ b/src/Video/Texture/Texture2D.cpp
@@ -52,7 +52,7 @@ Texture2D::~Texture2D() {
         delete texture;
 }
 
-const Texture* Texture2D::GetTexture() const {
+Texture* Texture2D::GetTexture() {
     return texture;
 }
 

--- a/src/Video/Texture/Texture2D.hpp
+++ b/src/Video/Texture/Texture2D.hpp
@@ -30,7 +30,7 @@ class Texture2D {
     /**
      * @return The low-level texture.
      */
-    const Texture* GetTexture() const;
+    Texture* GetTexture();
 
     /// Get whether the texture has been loaded yet.
     /**


### PR DESCRIPTION
Pipeline barriers tracking storage buffers are no longer conservative. Storage buffers
can now be written to from non-compute shaders.

Command buffers are now required to be recorded in the same order as they are submitted.