### PR TITLE
Frustum-Sphere intersection testing

### DIFF
--- a/src/Video/CMakeLists.txt
+++ b/src/Video/CMakeLists.txt
@@ -3,6 +3,7 @@ set(SRCS
     Renderer.cpp
     Culling/AxisAlignedBoundingBox.cpp
     Culling/Frustum.cpp
+    Culling/Sphere.cpp
     Geometry/Geometry2D.cpp
     Geometry/Geometry3D.cpp
     Geometry/Rectangle.cpp
@@ -20,6 +21,7 @@ set(HEADERS
     Renderer.hpp
     Culling/AxisAlignedBoundingBox.hpp
     Culling/Frustum.hpp
+    Culling/Sphere.hpp
     Geometry/Geometry2D.hpp
     Geometry/Geometry3D.hpp
     Geometry/Rectangle.hpp

--- a/src/Video/Culling/AxisAlignedBoundingBox.cpp
+++ b/src/Video/Culling/AxisAlignedBoundingBox.cpp
@@ -11,6 +11,6 @@ AxisAlignedBoundingBox::AxisAlignedBoundingBox(const glm::vec3& dimensions, cons
     this->maxVertex = maxVertex;
 }
 
-bool AxisAlignedBoundingBox::Collide(const Frustum& frustum) const {
-    return frustum.Collide(*this);
+bool AxisAlignedBoundingBox::Intersects(const Frustum& frustum) const {
+    return frustum.Intersects(*this);
 }

--- a/src/Video/Culling/AxisAlignedBoundingBox.hpp
+++ b/src/Video/Culling/AxisAlignedBoundingBox.hpp
@@ -20,12 +20,12 @@ class AxisAlignedBoundingBox {
      */
     AxisAlignedBoundingBox(const glm::vec3& dimensions = {0.f, 0.f, 0.f}, const glm::vec3& origin = {0.f, 0.f, 0.f}, const glm::vec3& minVertex = {0.f, 0.f, 0.f}, const glm::vec3& maxVertex = {0.f, 0.f, 0.f});
 
-    /// Check collision between the axis-aligned bounding box and a frustum.
+    /// Check interesection between the axis-aligned bounding box and a frustum.
     /**
-     * @param frustum The frustum to check collision against.
-     * @return Whether there was a collision.
+     * @param frustum The frustum to check intersection against.
+     * @return Whether the bounding volumes intersect.
      */
-    bool Collide(const Frustum& frustum) const;
+    bool Intersects(const Frustum& frustum) const;
 
     /// Dimensions.
     glm::vec3 dimensions;

--- a/src/Video/Culling/Frustum.cpp
+++ b/src/Video/Culling/Frustum.cpp
@@ -1,6 +1,7 @@
 #include "Frustum.hpp"
 
 #include "AxisAlignedBoundingBox.hpp"
+#include "Sphere.hpp"
 #include <glm/gtc/matrix_access.hpp>
 
 using namespace Video;
@@ -49,7 +50,7 @@ Frustum::Frustum(const glm::mat4& matrix) {
 	}
 }
 
-bool Frustum::Collide(const AxisAlignedBoundingBox& aabb) const {
+bool Frustum::Intersects(const AxisAlignedBoundingBox& aabb) const {
     // Define the AABB's vertices.
     glm::vec3 vertices[8];
     vertices[0] = aabb.minVertex;
@@ -76,6 +77,15 @@ bool Frustum::Collide(const AxisAlignedBoundingBox& aabb) const {
             return false;
     }
     return true;
+}
+
+bool Frustum::Intersects(const Sphere& sphere) const {
+    for (int plane = 0; plane < 6; plane++) {
+		if (DistanceToPoint(planes[plane], sphere.origin) < -sphere.radius) {
+			return false;
+		}
+	}
+	return true;
 }
 
 float Frustum::DistanceToPoint(const glm::vec4& plane, const glm::vec3& point) {

--- a/src/Video/Culling/Frustum.hpp
+++ b/src/Video/Culling/Frustum.hpp
@@ -4,6 +4,7 @@
 
 namespace Video {
 class AxisAlignedBoundingBox;
+class Sphere;
 
 /// A viewing frustum.
 /**
@@ -17,12 +18,19 @@ class Frustum {
      */
     explicit Frustum(const glm::mat4& matrix);
 
-    /// Check collision between frustum and an axis-aligned bounding box.
+    /// Check intersection between frustum and an axis-aligned bounding box.
     /**
-     * @param aabb The axis-aligned bounding box to check collision against.
-     * @return Whether there was a collision
+     * @param aabb The axis-aligned bounding box to check intersection against.
+     * @return Whether the bounding volumes intersect.
      */
-    bool Collide(const AxisAlignedBoundingBox& aabb) const;
+    bool Intersects(const AxisAlignedBoundingBox& aabb) const;
+
+    /// Check intersection between frustum and a sphere.
+    /**
+     * @param sphere The sphere to check intersection against.
+     * @return Whether the bounding volumes intersect.
+     */
+    bool Intersects(const Sphere& sphere) const;
 
   private:
     glm::vec4 planes[6];

--- a/src/Video/Culling/Sphere.cpp
+++ b/src/Video/Culling/Sphere.cpp
@@ -1,0 +1,14 @@
+#include "Sphere.hpp"
+
+#include "Frustum.hpp"
+
+using namespace Video;
+
+Sphere::Sphere(const glm::vec3& origin, float radius) {
+    this->origin = origin;
+    this->radius = radius;
+}
+
+bool Sphere::Intersects(const Frustum& frustum) const {
+    return frustum.Intersects(*this);
+}

--- a/src/Video/Culling/Sphere.hpp
+++ b/src/Video/Culling/Sphere.hpp
@@ -1,0 +1,34 @@
+#pragma once
+
+#include <glm/glm.hpp>
+
+namespace Video {
+class Frustum;
+
+/// A sphere.
+/**
+ * Used for intersection testing.
+ */
+class Sphere {
+  public:
+    /// Create new sphere.
+    /**
+     * @param origin Origin.
+     * @param radius Radius.
+     */
+    Sphere(const glm::vec3& origin, float radius);
+
+    /// Check interesection between the sphere and a frustum.
+    /**
+     * @param frustum The frustum to check intersection against.
+     * @return Whether the bounding volumes intersect.
+     */
+    bool Intersects(const Frustum& frustum) const;
+
+    /// Origin.
+    glm::vec3 origin;
+
+    /// Radius.
+    float radius;
+};
+} // namespace Video


### PR DESCRIPTION
Check frustum against spheres instead of AABBs when frustum culling lights.

This should be more accurate, and makes frustum culling 1000 lights go from ~1ms to ~0.5ms. Measured on AMD Ryzen 5 2600X (3.6 GHz, 6 cores).