### PR TITLE
Separate sampler objects

### DIFF
--- a/src/Editor/ImGui/Implementation.cpp
+++ b/src/Editor/ImGui/Implementation.cpp
@@ -195,6 +195,7 @@ void Render() {
     commandBuffer->BindGeometry(geometryBinding);
 
     // Draw all the commands in the draw list.
+    const Video::Sampler* sampler = g_LowLevelRenderer->GetSampler(Video::Sampler::Filter::LINEAR, Video::Sampler::Clamping::CLAMP_TO_EDGE);
     unsigned int baseVertex = 0;
     unsigned int firstIndex = 0;
     for (int n = 0; n < draw_data->CmdListsCount; n++) {
@@ -205,7 +206,7 @@ void Render() {
             if (pcmd->UserCallback) {
                 pcmd->UserCallback(cmdList, pcmd);
             } else {
-                commandBuffer->BindMaterial({static_cast<Video::Texture*>(pcmd->TextureId)});
+                commandBuffer->BindMaterial({{static_cast<Video::Texture*>(pcmd->TextureId), sampler}});
                 commandBuffer->SetScissor(glm::uvec2((int)pcmd->ClipRect.x, (int)(pcmd->ClipRect.y)), glm::uvec2((int)(pcmd->ClipRect.z - pcmd->ClipRect.x), (int)(pcmd->ClipRect.w - pcmd->ClipRect.y)));
                 commandBuffer->DrawIndexed(pcmd->ElemCount, firstIndex, baseVertex);
             }

--- a/src/Video/CMakeLists.txt
+++ b/src/Video/CMakeLists.txt
@@ -50,6 +50,7 @@ set(HEADERS
     LowLevelRenderer/Interface/RenderPass.hpp
     LowLevelRenderer/Interface/RenderPassAllocator.hpp
     LowLevelRenderer/Interface/RenderTargetAllocator.hpp
+    LowLevelRenderer/Interface/Sampler.hpp
     LowLevelRenderer/Interface/Shader.hpp
     LowLevelRenderer/Interface/ShaderProgram.hpp
     LowLevelRenderer/Interface/Texture.hpp
@@ -80,6 +81,7 @@ if(OpenGLRenderer)
         LowLevelRenderer/OpenGL/OpenGLRenderPass.cpp
         LowLevelRenderer/OpenGL/OpenGLRenderPassAllocator.cpp
         LowLevelRenderer/OpenGL/OpenGLRenderTargetAllocator.cpp
+        LowLevelRenderer/OpenGL/OpenGLSampler.cpp
         LowLevelRenderer/OpenGL/OpenGLShader.cpp
         LowLevelRenderer/OpenGL/OpenGLShaderProgram.cpp
         LowLevelRenderer/OpenGL/OpenGLTexture.cpp
@@ -98,6 +100,7 @@ if(OpenGLRenderer)
         LowLevelRenderer/OpenGL/OpenGLRenderPass.hpp
         LowLevelRenderer/OpenGL/OpenGLRenderPassAllocator.hpp
         LowLevelRenderer/OpenGL/OpenGLRenderTargetAllocator.hpp
+        LowLevelRenderer/OpenGL/OpenGLSampler.hpp
         LowLevelRenderer/OpenGL/OpenGLShader.hpp
         LowLevelRenderer/OpenGL/OpenGLShaderProgram.hpp
         LowLevelRenderer/OpenGL/OpenGLTexture.hpp
@@ -126,6 +129,7 @@ if(VulkanRenderer)
         LowLevelRenderer/Vulkan/VulkanRenderPass.cpp
         LowLevelRenderer/Vulkan/VulkanRenderPassAllocator.cpp
         LowLevelRenderer/Vulkan/VulkanRenderTargetAllocator.cpp
+        LowLevelRenderer/Vulkan/VulkanSampler.cpp
         LowLevelRenderer/Vulkan/VulkanShader.cpp
         LowLevelRenderer/Vulkan/VulkanShaderProgram.cpp
         LowLevelRenderer/Vulkan/VulkanTexture.cpp
@@ -145,6 +149,7 @@ if(VulkanRenderer)
         LowLevelRenderer/Vulkan/VulkanRenderPass.hpp
         LowLevelRenderer/Vulkan/VulkanRenderPassAllocator.hpp
         LowLevelRenderer/Vulkan/VulkanRenderTargetAllocator.hpp
+        LowLevelRenderer/Vulkan/VulkanSampler.hpp
         LowLevelRenderer/Vulkan/VulkanShader.hpp
         LowLevelRenderer/Vulkan/VulkanShaderProgram.hpp
         LowLevelRenderer/Vulkan/VulkanTexture.hpp

--- a/src/Video/LowLevelRenderer/Interface/CommandBuffer.hpp
+++ b/src/Video/LowLevelRenderer/Interface/CommandBuffer.hpp
@@ -5,12 +5,14 @@
 #include "ShaderProgram.hpp"
 #include "RenderPass.hpp"
 #include <initializer_list>
+#include <utility>
 
 namespace Video {
 
 class VertexDescription;
 class GeometryBinding;
 class Texture;
+class Sampler;
 class Buffer;
 class GraphicsPipeline;
 class ComputePipeline;
@@ -114,7 +116,7 @@ class CommandBuffer {
     /**
      * @param textures The textures to bind to the graphics pipeline.
      */
-    virtual void BindMaterial(std::initializer_list<Texture*> textures) = 0;
+    virtual void BindMaterial(std::initializer_list<std::pair<Texture*, const Sampler*>> textures) = 0;
 
     /// Update push constants.
     /**

--- a/src/Video/LowLevelRenderer/Interface/LowLevelRenderer.hpp
+++ b/src/Video/LowLevelRenderer/Interface/LowLevelRenderer.hpp
@@ -6,6 +6,7 @@
 #include "RenderPass.hpp"
 #include "Shader.hpp"
 #include "Texture.hpp"
+#include "Sampler.hpp"
 #include "GraphicsPipeline.hpp"
 
 #include <glm/glm.hpp>
@@ -139,13 +140,26 @@ class LowLevelRenderer {
      * @param format The format of the texture.
      * @param components The number of components in the texture, 0 if no texture data is supplied.
      * @param data The texture data to upload, or nullptr.
+     * 
+     * @return The created texture.
      */
     virtual Texture* CreateTexture(const glm::uvec2 size, Texture::Format format, int components, unsigned char* data) = 0;
+
+    /// Get a sampler.
+    /**
+     * @param filter The interpolation to apply.
+     * @param clamping How to handle sampling outside the texture dimensions.
+     * 
+     * @return The requested sampler.
+     */
+    virtual const Sampler* GetSampler(Sampler::Filter filter, Sampler::Clamping clamping) const = 0;
 
     /// Create a render target.
     /**
      * @param size The size of the texture, in pixels.
      * @param format The format of the texture.
+     * 
+     * @return The created texture.
      */
     virtual Texture* CreateRenderTarget(const glm::uvec2& size, Texture::Format format) = 0;
 
@@ -160,12 +174,16 @@ class LowLevelRenderer {
      * @param shaderProgram The shader program to use.
      * @param configuration The configuration of the pipeline.
      * @param vertexDescription The description of the vertex input to the pipeline.
+     * 
+     * @return The created graphics pipeline.
      */
     virtual GraphicsPipeline* CreateGraphicsPipeline(const ShaderProgram* shaderProgram, const GraphicsPipeline::Configuration& configuration, const VertexDescription* vertexDescription = nullptr) = 0;
 
     /// Create a compute pipeline.
     /**
      * @param shaderProgram The shader program to use.
+     * 
+     * @return The created compute pipeline.
      */
     virtual ComputePipeline* CreateComputePipeline(const ShaderProgram* shaderProgram) = 0;
 

--- a/src/Video/LowLevelRenderer/Interface/Sampler.hpp
+++ b/src/Video/LowLevelRenderer/Interface/Sampler.hpp
@@ -1,0 +1,32 @@
+#pragma once
+
+namespace Video {
+
+/// Determines how a texture should be sampled.
+class Sampler {
+  public:
+    /// The interpolation to apply.
+    enum class Filter {
+        NEAREST, ///< Nearest neighbor.
+        LINEAR, ///< Bilinear filtering.
+        COUNT ///< Number of entries in enum.
+    };
+
+    /// How to handle sampling outside the texture dimensions.
+    enum class Clamping {
+        REPEAT, ///< Repeat the texture.
+        CLAMP_TO_EDGE, ///< Clamp to the edge of the texture.
+        COUNT ///< Number of entries in enum.
+    };
+
+    /// Create a new sampler.
+    Sampler() {}
+
+    /// Destructor.
+    virtual ~Sampler() {}
+
+  private:
+    Sampler(const Sampler& other) = delete;
+};
+
+} // namespace Video

--- a/src/Video/LowLevelRenderer/OpenGL/OpenGLCommandBuffer.hpp
+++ b/src/Video/LowLevelRenderer/OpenGL/OpenGLCommandBuffer.hpp
@@ -47,7 +47,7 @@ class OpenGLCommandBuffer : public CommandBuffer {
     void BindGeometry(GeometryBinding* geometryBinding) final;
     void BindUniformBuffer(ShaderProgram::BindingType bindingType, Buffer* uniformBuffer) final;
     void BindStorageBuffers(std::initializer_list<Buffer*> buffers) final;
-    void BindMaterial(std::initializer_list<Texture*> textures) final;
+    void BindMaterial(std::initializer_list<std::pair<Texture*, const Sampler*>> textures) final;
     void PushConstants(const void* data) final;
     void Draw(unsigned int vertexCount, unsigned int firstVertex) final;
     void DrawIndexed(unsigned int indexCount, unsigned int firstIndex, unsigned int baseVertex) final;
@@ -151,6 +151,7 @@ class OpenGLCommandBuffer : public CommandBuffer {
     struct BindTextureCommand {
         GLenum slot;
         GLuint texture;
+        GLuint sampler;
     };
 
     struct BindUniformBufferCommand {

--- a/src/Video/LowLevelRenderer/OpenGL/OpenGLRenderer.hpp
+++ b/src/Video/LowLevelRenderer/OpenGL/OpenGLRenderer.hpp
@@ -13,6 +13,7 @@ class OpenGLShaderProgram;
 class OpenGLBufferAllocator;
 class OpenGLRenderPassAllocator;
 class OpenGLRenderTargetAllocator;
+class OpenGLSampler;
 
 /// Low-level renderer implementing OpenGL.
 class OpenGLRenderer : public LowLevelRenderer {
@@ -37,6 +38,7 @@ class OpenGLRenderer : public LowLevelRenderer {
     Shader* CreateShader(const ShaderSource& shaderSource, Shader::Type type) final;
     ShaderProgram* CreateShaderProgram(std::initializer_list<const Shader*> shaders) final;
     Texture* CreateTexture(const glm::uvec2 size, Texture::Format format, int components, unsigned char* data) final;
+    const Sampler* GetSampler(Sampler::Filter filter, Sampler::Clamping clamping) const final;
     Texture* CreateRenderTarget(const glm::uvec2& size, Texture::Format format) final;
     void FreeRenderTarget(Texture* renderTarget) final;
     GraphicsPipeline* CreateGraphicsPipeline(const ShaderProgram* shaderProgram, const GraphicsPipeline::Configuration& configuration, const VertexDescription* vertexDescription = nullptr) final;
@@ -71,6 +73,8 @@ class OpenGLRenderer : public LowLevelRenderer {
     OpenGLBufferAllocator* bufferAllocator;
     OpenGLRenderPassAllocator* renderPassAllocator;
     OpenGLRenderTargetAllocator* renderTargetAllocator;
+
+    OpenGLSampler* samplers[static_cast<uint32_t>(Sampler::Filter::COUNT) * static_cast<uint32_t>(Sampler::Clamping::COUNT)];
 
     OptionalFeatures optionalFeatures;
 

--- a/src/Video/LowLevelRenderer/OpenGL/OpenGLSampler.cpp
+++ b/src/Video/LowLevelRenderer/OpenGL/OpenGLSampler.cpp
@@ -1,0 +1,48 @@
+#include "OpenGLSampler.hpp"
+
+#include <cassert>
+
+namespace Video {
+
+OpenGLSampler::OpenGLSampler(Filter filter, Clamping clamping) {
+    assert(filter < Filter::COUNT);
+    assert(clamping < Clamping::COUNT);
+
+    glGenSamplers(1, &sampler);
+
+    switch (filter) {
+    case Filter::NEAREST:
+        glSamplerParameteri(sampler, GL_TEXTURE_MIN_FILTER, GL_NEAREST_MIPMAP_NEAREST);
+        glSamplerParameteri(sampler, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+        break;
+    case Filter::LINEAR:
+        glSamplerParameteri(sampler, GL_TEXTURE_MIN_FILTER, GL_LINEAR_MIPMAP_LINEAR);
+        glSamplerParameteri(sampler, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+        break;
+    default:
+        assert(false);
+    }
+
+    switch (clamping) {
+    case Clamping::REPEAT:
+        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_REPEAT);
+        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_REPEAT);
+        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_R, GL_REPEAT);
+        break;
+    case Clamping::CLAMP_TO_EDGE:
+        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_R, GL_CLAMP_TO_EDGE);
+        break;
+    default:
+        assert(false);
+    }
+}
+
+OpenGLSampler::~OpenGLSampler() {}
+
+GLuint OpenGLSampler::GetSampler() const {
+    return sampler;
+}
+
+} // namespace Video

--- a/src/Video/LowLevelRenderer/OpenGL/OpenGLSampler.hpp
+++ b/src/Video/LowLevelRenderer/OpenGL/OpenGLSampler.hpp
@@ -1,0 +1,34 @@
+#pragma once
+
+#include "../Interface/Sampler.hpp"
+
+#include <glad/glad.h>
+
+namespace Video {
+
+/// OpenGL implementation of Sampler.
+class OpenGLSampler : public Sampler {
+  public:
+    /// Create new OpenGL sampler.
+    /**
+     * @param filter The interpolation to apply.
+     * @param clamping How to handle sampling outside the texture dimensions.
+     */
+    OpenGLSampler(Filter filter, Clamping clamping);
+
+    /// Destructor.
+    ~OpenGLSampler() final;
+
+    /// Get the sampler.
+    /**
+     * @return The sampler.
+     */
+    GLuint GetSampler() const;
+
+  private:
+    OpenGLSampler(const OpenGLSampler& other) = delete;
+
+    GLuint sampler = 0;
+};
+
+} // namespace Video

--- a/src/Video/LowLevelRenderer/OpenGL/OpenGLTexture.cpp
+++ b/src/Video/LowLevelRenderer/OpenGL/OpenGLTexture.cpp
@@ -40,33 +40,6 @@ OpenGLTexture::OpenGLTexture(const glm::uvec2 size, Texture::Type type, Texture:
     // Upload the image data.
     glTexImage2D(GL_TEXTURE_2D, 0, internalFormat, size.x, size.y, 0, dataFormat, GL_UNSIGNED_BYTE, (data != nullptr) ? data : NULL);
 
-    /// @todo Configurable filtering.
-    switch (type) {
-    case Texture::Type::COLOR:
-        // Set texture parameters.
-        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR_MIPMAP_LINEAR);
-        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
-        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_REPEAT);
-        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_REPEAT);
-
-        // Generate mipmaps.
-        glGenerateMipmap(GL_TEXTURE_2D);
-        break;
-    case Texture::Type::RENDER_COLOR:
-        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
-        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
-        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
-        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
-        break;
-    case Texture::Type::RENDER_DEPTH:
-        // Set texture parameters.
-        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
-        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
-        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
-        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
-        break;
-    }
-
     glBindTexture(GL_TEXTURE_2D, 0);
 }
 

--- a/src/Video/LowLevelRenderer/Vulkan/VulkanCommandBuffer.cpp
+++ b/src/Video/LowLevelRenderer/Vulkan/VulkanCommandBuffer.cpp
@@ -290,16 +290,16 @@ void VulkanCommandBuffer::BindStorageBuffers(std::initializer_list<Buffer*> buff
     }
 }
 
-void VulkanCommandBuffer::BindMaterial(std::initializer_list<Texture*> textures) {
+void VulkanCommandBuffer::BindMaterial(std::initializer_list<std::pair<Texture*, const Sampler*>> textures) {
     assert(inRenderPass);
 
-    for (Texture* texture : textures) {
-        assert(texture->GetType() != Texture::Type::RENDER_DEPTH);
-        if (texture->GetType() == Texture::Type::RENDER_COLOR) {
-            TransitionTexture(static_cast<VulkanTexture*>(texture), VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
+    for (auto& texture : textures) {
+        assert(texture.first->GetType() != Texture::Type::RENDER_DEPTH);
+        if (texture.first->GetType() == Texture::Type::RENDER_COLOR) {
+            TransitionTexture(static_cast<VulkanTexture*>(texture.first), VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
         }
     }
-
+    
     VkDescriptorSet descriptorSet = vulkanRenderer->GetDescriptorSet(textures);
     vkCmdBindDescriptorSets(renderPassCommandBuffer, VK_PIPELINE_BIND_POINT_GRAPHICS, currentGraphicsPipeline->GetPipelineLayout(), ShaderProgram::BindingType::MATERIAL, 1, &descriptorSet, 0, nullptr);
 }

--- a/src/Video/LowLevelRenderer/Vulkan/VulkanCommandBuffer.hpp
+++ b/src/Video/LowLevelRenderer/Vulkan/VulkanCommandBuffer.hpp
@@ -52,7 +52,7 @@ class VulkanCommandBuffer : public CommandBuffer {
     void BindGeometry(GeometryBinding* geometryBinding) final;
     void BindUniformBuffer(ShaderProgram::BindingType bindingType, Buffer* uniformBuffer) final;
     void BindStorageBuffers(std::initializer_list<Buffer*> buffers) final;
-    void BindMaterial(std::initializer_list<Texture*> textures) final;
+    void BindMaterial(std::initializer_list<std::pair<Texture*, const Sampler*>> textures) final;
     void PushConstants(const void* data) final;
     void Draw(unsigned int vertexCount, unsigned int firstVertex) final;
     void DrawIndexed(unsigned int indexCount, unsigned int firstIndex, unsigned int baseVertex) final;

--- a/src/Video/LowLevelRenderer/Vulkan/VulkanRenderer.hpp
+++ b/src/Video/LowLevelRenderer/Vulkan/VulkanRenderer.hpp
@@ -16,6 +16,7 @@ class VulkanBuffer;
 class VulkanBufferAllocator;
 class VulkanRenderPassAllocator;
 class VulkanRenderTargetAllocator;
+class VulkanSampler;
 
 /// Low-level renderer implementing Vulkan.
 class VulkanRenderer : public LowLevelRenderer {
@@ -40,6 +41,7 @@ class VulkanRenderer : public LowLevelRenderer {
     Shader* CreateShader(const ShaderSource& shaderSource, Shader::Type type) final;
     ShaderProgram* CreateShaderProgram(std::initializer_list<const Shader*> shaders) final;
     Texture* CreateTexture(const glm::uvec2 size, Texture::Format format, int components, unsigned char* data) final;
+    const Sampler* GetSampler(Sampler::Filter filter, Sampler::Clamping clamping) const final;
     Texture* CreateRenderTarget(const glm::uvec2& size, Texture::Format format) final;
     void FreeRenderTarget(Texture* renderTarget) final;
     GraphicsPipeline* CreateGraphicsPipeline(const ShaderProgram* shaderProgram, const GraphicsPipeline::Configuration& configuration, const VertexDescription* vertexDescription = nullptr) final;
@@ -111,7 +113,7 @@ class VulkanRenderer : public LowLevelRenderer {
      *
      * @return The descriptor set.
      */
-    VkDescriptorSet GetDescriptorSet(std::initializer_list<Texture*> textures);
+    VkDescriptorSet GetDescriptorSet(std::initializer_list<std::pair<Texture*, const Sampler*>> textures);
 
     /// Get the current frame's query pool.
     /**
@@ -167,6 +169,8 @@ class VulkanRenderer : public LowLevelRenderer {
     void CreateQueries();
     void ResetQueries(uint32_t queryPool);
 
+    void CreateSamplers();
+
     void AcquireSwapChainImage();
 
     VkInstance instance;
@@ -214,6 +218,8 @@ class VulkanRenderer : public LowLevelRenderer {
     unsigned int currentMaterialDescriptorSet[bakedMaterialDescriptorSetLayouts];
 
     VkDescriptorPool descriptorPool;
+
+    VulkanSampler* samplers[static_cast<uint32_t>(Sampler::Filter::COUNT) * static_cast<uint32_t>(Sampler::Clamping::COUNT)];
 
     OptionalFeatures optionalFeatures;
     

--- a/src/Video/LowLevelRenderer/Vulkan/VulkanSampler.cpp
+++ b/src/Video/LowLevelRenderer/Vulkan/VulkanSampler.cpp
@@ -1,0 +1,69 @@
+#include "VulkanSampler.hpp"
+
+#include <cassert>
+#include <Utility/Log.hpp>
+
+namespace Video {
+
+VulkanSampler::VulkanSampler(VkDevice device, Filter filter, Clamping clamping) {
+    assert(filter < Filter::COUNT);
+    assert(clamping < Clamping::COUNT);
+
+    this->device = device;
+
+    /// @todo Anisotropic filtering.
+    VkSamplerCreateInfo samplerCreateInfo = {};
+    samplerCreateInfo.sType = VK_STRUCTURE_TYPE_SAMPLER_CREATE_INFO;
+    samplerCreateInfo.mipLodBias = 0.0f;
+    samplerCreateInfo.anisotropyEnable = VK_FALSE;
+    samplerCreateInfo.maxAnisotropy = 1.0f;
+    samplerCreateInfo.compareEnable = VK_FALSE;
+    samplerCreateInfo.minLod = 0.0f;
+    samplerCreateInfo.maxLod = 1000.0f;
+    samplerCreateInfo.borderColor = VK_BORDER_COLOR_FLOAT_TRANSPARENT_BLACK;
+    samplerCreateInfo.unnormalizedCoordinates = VK_FALSE;
+
+    switch (filter) {
+    case Filter::NEAREST:
+        samplerCreateInfo.magFilter = VK_FILTER_NEAREST;
+        samplerCreateInfo.minFilter = VK_FILTER_NEAREST;
+        samplerCreateInfo.mipmapMode = VK_SAMPLER_MIPMAP_MODE_NEAREST;
+        break;
+    case Filter::LINEAR:
+        samplerCreateInfo.magFilter = VK_FILTER_LINEAR;
+        samplerCreateInfo.minFilter = VK_FILTER_LINEAR;
+        samplerCreateInfo.mipmapMode = VK_SAMPLER_MIPMAP_MODE_LINEAR;
+        break;
+    default:
+        assert(false);
+    }
+
+    switch (clamping) {
+    case Clamping::REPEAT:
+        samplerCreateInfo.addressModeU = VK_SAMPLER_ADDRESS_MODE_REPEAT;
+        samplerCreateInfo.addressModeV = VK_SAMPLER_ADDRESS_MODE_REPEAT;
+        samplerCreateInfo.addressModeW = VK_SAMPLER_ADDRESS_MODE_REPEAT;
+        break;
+    case Clamping::CLAMP_TO_EDGE:
+        samplerCreateInfo.addressModeU = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE;
+        samplerCreateInfo.addressModeV = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE;
+        samplerCreateInfo.addressModeW = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE;
+        break;
+    default:
+        assert(false);
+    }
+
+    if (vkCreateSampler(device, &samplerCreateInfo, nullptr, &sampler) != VK_SUCCESS) {
+        Log(Log::ERR) << "Failed to create sampler.\n";
+    }
+}
+
+VulkanSampler::~VulkanSampler() {
+    vkDestroySampler(device, sampler, nullptr);
+}
+
+VkSampler VulkanSampler::GetSampler() const {
+    return sampler;
+}
+
+}

--- a/src/Video/LowLevelRenderer/Vulkan/VulkanSampler.hpp
+++ b/src/Video/LowLevelRenderer/Vulkan/VulkanSampler.hpp
@@ -1,0 +1,38 @@
+#pragma once
+
+#include "../Interface/Sampler.hpp"
+
+#include <vulkan/vulkan.h>
+
+namespace Video {
+
+class VulkanRenderer;
+
+/// Vulkan implementation of Sampler.
+class VulkanSampler : public Sampler {
+  public:
+    /// Create new Vulkan sampler.
+    /**
+     * @param device The Vulkan device.
+     * @param filter The interpolation to apply.
+     * @param clamping How to handle sampling outside the texture dimensions.
+     */
+    VulkanSampler(VkDevice device, Filter filter, Clamping clamping);
+
+    /// Destructor.
+    ~VulkanSampler() final;
+
+    /// Get the sampler.
+    /**
+     * @return The sampler.
+     */
+    VkSampler GetSampler() const;
+
+  private:
+    VulkanSampler(const VulkanSampler& other) = delete;
+
+    VkDevice device;
+    VkSampler sampler = VK_NULL_HANDLE;
+};
+
+} // namespace Video

--- a/src/Video/LowLevelRenderer/Vulkan/VulkanTexture.cpp
+++ b/src/Video/LowLevelRenderer/Vulkan/VulkanTexture.cpp
@@ -133,52 +133,6 @@ VulkanTexture::VulkanTexture(VulkanRenderer& vulkanRenderer, VkDevice device, Vk
         GenerateMipMaps(vulkanRenderer, physicalDevice, size, mipLevels, internalFormat);
     }
 
-    if (type != Texture::Type::RENDER_DEPTH) {
-        /// @todo These could be cached somewhere since they're not image specific.
-        VkSamplerCreateInfo samplerCreateInfo = {};
-        samplerCreateInfo.sType = VK_STRUCTURE_TYPE_SAMPLER_CREATE_INFO;
-        samplerCreateInfo.mipLodBias = 0.0f;
-        samplerCreateInfo.anisotropyEnable = VK_FALSE;
-        samplerCreateInfo.maxAnisotropy = 1.0f;
-        samplerCreateInfo.compareEnable = VK_FALSE;
-        samplerCreateInfo.minLod = 0.0f;
-        samplerCreateInfo.maxLod = 1000.0f;
-        samplerCreateInfo.borderColor = VK_BORDER_COLOR_FLOAT_TRANSPARENT_BLACK;
-        samplerCreateInfo.unnormalizedCoordinates = VK_FALSE;
-
-        /// @todo Configurable filtering.
-        switch (type) {
-        case Texture::Type::COLOR:
-            samplerCreateInfo.magFilter = VK_FILTER_LINEAR;
-            samplerCreateInfo.minFilter = VK_FILTER_LINEAR;
-            samplerCreateInfo.mipmapMode = VK_SAMPLER_MIPMAP_MODE_LINEAR;
-            samplerCreateInfo.addressModeU = VK_SAMPLER_ADDRESS_MODE_REPEAT;
-            samplerCreateInfo.addressModeV = VK_SAMPLER_ADDRESS_MODE_REPEAT;
-            samplerCreateInfo.addressModeW = VK_SAMPLER_ADDRESS_MODE_REPEAT;
-            break;
-        case Texture::Type::RENDER_COLOR:
-            samplerCreateInfo.magFilter = VK_FILTER_LINEAR;
-            samplerCreateInfo.minFilter = VK_FILTER_LINEAR;
-            samplerCreateInfo.mipmapMode = VK_SAMPLER_MIPMAP_MODE_NEAREST;
-            samplerCreateInfo.addressModeU = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE;
-            samplerCreateInfo.addressModeV = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE;
-            samplerCreateInfo.addressModeW = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE;
-            break;
-        case Texture::Type::RENDER_DEPTH:
-            samplerCreateInfo.magFilter = VK_FILTER_NEAREST;
-            samplerCreateInfo.minFilter = VK_FILTER_NEAREST;
-            samplerCreateInfo.mipmapMode = VK_SAMPLER_MIPMAP_MODE_NEAREST;
-            samplerCreateInfo.addressModeU = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE;
-            samplerCreateInfo.addressModeV = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE;
-            samplerCreateInfo.addressModeW = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE;
-            break;
-        }
-
-        if (vkCreateSampler(device, &samplerCreateInfo, nullptr, &sampler) != VK_SUCCESS) {
-            Log(Log::ERR) << "Failed to create sampler.\n";
-        }
-    }
-
     if (type == Texture::Type::RENDER_COLOR || type == Texture::Type::RENDER_DEPTH) {
         // Transition to attachment layout.
         currentLayout = (type == Texture::Type::RENDER_DEPTH ? VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL : VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL);
@@ -196,7 +150,6 @@ VulkanTexture::VulkanTexture(VulkanRenderer& vulkanRenderer, VkDevice device, Vk
 }
 
 VulkanTexture::~VulkanTexture() {
-    vkDestroySampler(device, sampler, nullptr);
     vkDestroyImageView(device, imageView, nullptr);
     vkDestroyImage(device, image, nullptr);
     vkFreeMemory(device, deviceMemory, nullptr);
@@ -212,10 +165,6 @@ VkImage VulkanTexture::GetImage() const {
 
 VkImageView VulkanTexture::GetImageView() const {
     return imageView;
-}
-
-VkSampler VulkanTexture::GetSampler() const {
-    return sampler;
 }
 
 VkImageLayout VulkanTexture::GetImageLayout() const {

--- a/src/Video/LowLevelRenderer/Vulkan/VulkanTexture.hpp
+++ b/src/Video/LowLevelRenderer/Vulkan/VulkanTexture.hpp
@@ -46,12 +46,6 @@ class VulkanTexture : public Texture {
      */
     VkImageView GetImageView() const;
 
-    /// Get the sampler.
-    /**
-     * @return The sampler.
-     */
-    VkSampler GetSampler() const;
-
     /// Get the current image layout.
     /**
      * @return The image layout.
@@ -75,7 +69,6 @@ class VulkanTexture : public Texture {
     VkImage image;
     VkDeviceMemory deviceMemory;
     VkImageView imageView;
-    VkSampler sampler = VK_NULL_HANDLE;
     VkImageLayout currentLayout;
 };
 

--- a/src/Video/PostProcessing/PostProcessing.hpp
+++ b/src/Video/PostProcessing/PostProcessing.hpp
@@ -11,6 +11,7 @@ class RenderSurface;
 class Filter;
 class CommandBuffer;
 class Texture;
+class Sampler;
 class Buffer;
 
 /// Applies post-processing effects to the rendered image.
@@ -77,6 +78,8 @@ class PostProcessing {
     Texture* outputTexture = nullptr;
 
     Texture* dummyTexture;
+
+    const Sampler* sampler;
 
     // Bloom.
     struct BloomData {

--- a/src/Video/RenderProgram/SpriteRenderProgram.cpp
+++ b/src/Video/RenderProgram/SpriteRenderProgram.cpp
@@ -53,6 +53,8 @@ SpriteRenderProgram::SpriteRenderProgram(LowLevelRenderer* lowLevelRenderer) {
     configuration.depthComparison = DepthComparison::LESS_EQUAL;
 
     graphicsPipeline = lowLevelRenderer->CreateGraphicsPipeline(shaderProgram, configuration, vertexDescription);
+
+    sampler = lowLevelRenderer->GetSampler(Sampler::Filter::LINEAR, Sampler::Clamping::CLAMP_TO_EDGE);
 }
 
 SpriteRenderProgram::~SpriteRenderProgram() {
@@ -89,7 +91,7 @@ void SpriteRenderProgram::PreRender(CommandBuffer& commandBuffer, const glm::mat
 
 void SpriteRenderProgram::Render(CommandBuffer& commandBuffer, Video::Texture2D* texture, const glm::vec2& size, const glm::vec2& pivot, const glm::mat4& modelMatrix, const glm::vec4& tint) const {
     // Textures
-    commandBuffer.BindMaterial({texture->GetTexture()});
+    commandBuffer.BindMaterial({{texture->GetTexture(), sampler}});
 
     // Render sprite.
     struct PushConstants {

--- a/src/Video/RenderProgram/SpriteRenderProgram.hpp
+++ b/src/Video/RenderProgram/SpriteRenderProgram.hpp
@@ -12,6 +12,7 @@ class GraphicsPipeline;
 class Buffer;
 class CommandBuffer;
 class Texture;
+class Sampler;
 class GeometryBinding;
 class VertexDescription;
 
@@ -58,6 +59,8 @@ class SpriteRenderProgram : public RenderProgram {
     Shader* fragmentShader;
     ShaderProgram* shaderProgram;
     GraphicsPipeline* graphicsPipeline;
+
+    const Sampler* sampler;
 
     struct MatricesValues {
         glm::mat4 viewProjectionMatrix;

--- a/src/Video/RenderProgram/StaticRenderProgram.cpp
+++ b/src/Video/RenderProgram/StaticRenderProgram.cpp
@@ -46,6 +46,8 @@ StaticRenderProgram::StaticRenderProgram(LowLevelRenderer* lowLevelRenderer) {
     configuration.depthComparison = DepthComparison::LESS;
     configuration.depthMode = DepthMode::TEST_WRITE;
     depthGraphicsPipeline = lowLevelRenderer->CreateGraphicsPipeline(depthShaderProgram, configuration, vertexDescription);
+
+    sampler = lowLevelRenderer->GetSampler(Sampler::Filter::LINEAR, Sampler::Clamping::REPEAT);
 }
 
 StaticRenderProgram::~StaticRenderProgram() {
@@ -118,7 +120,11 @@ void StaticRenderProgram::Render(CommandBuffer& commandBuffer, Geometry::Geometr
     commandBuffer.BindGeometry(geometry->GetGeometryBinding());
 
     // Textures
-    commandBuffer.BindMaterial({ textureAlbedo->GetTexture(), textureNormal->GetTexture(), textureRoughnessMetallic->GetTexture() });
+    commandBuffer.BindMaterial({
+        {textureAlbedo->GetTexture(), sampler},
+        {textureNormal->GetTexture(), sampler},
+        {textureRoughnessMetallic->GetTexture(), sampler}
+    });
 
     // Render model.
     struct PushConstants {

--- a/src/Video/RenderProgram/StaticRenderProgram.hpp
+++ b/src/Video/RenderProgram/StaticRenderProgram.hpp
@@ -13,6 +13,7 @@ class GraphicsPipeline;
 class Buffer;
 class CommandBuffer;
 class Texture;
+class Sampler;
 class VertexDescription;
 namespace Geometry {
 class Geometry3D;
@@ -81,6 +82,8 @@ class StaticRenderProgram : public RenderProgram {
     Shader* fragmentShader;
     ShaderProgram* shaderProgram;
     GraphicsPipeline* graphicsPipeline;
+
+    const Sampler* sampler;
 
     struct MatricesValues {
         glm::mat4 viewProjectionMatrix;

--- a/src/Video/Renderer.cpp
+++ b/src/Video/Renderer.cpp
@@ -81,6 +81,8 @@ Renderer::Renderer(GraphicsAPI graphicsAPI, GLFWwindow* window) {
 		blitGraphicsPipeline = lowLevelRenderer->CreateGraphicsPipeline(blitShaderProgram, configuration);
 	}
 
+    sampler = lowLevelRenderer->GetSampler(Sampler::Filter::LINEAR, Sampler::Clamping::CLAMP_TO_EDGE);
+
     // Create quad geometry.
     {
         glm::vec2 vertex[6];
@@ -217,7 +219,7 @@ void Renderer::Render(const RenderScene& renderScene) {
         commandBuffer->BeginRenderPass(outputTexture, firstCamera ? RenderPass::LoadOperation::CLEAR : RenderPass::LoadOperation::LOAD, nullptr, RenderPass::LoadOperation::DONT_CARE, "Blit");
         commandBuffer->BindGraphicsPipeline(blitGraphicsPipeline);
         commandBuffer->SetViewportAndScissor(cameraOffset, cameraSize);
-        commandBuffer->BindMaterial({ postProcessingTexture });
+        commandBuffer->BindMaterial({{postProcessingTexture, sampler}});
         commandBuffer->Draw(3);
         commandBuffer->EndRenderPass();
 
@@ -405,7 +407,7 @@ void Renderer::RenderIcons(const RenderScene& renderScene, const RenderScene::Ca
         PrepareRenderingIcons(camera.viewProjectionMatrix, camera.position, up);
 
         for (const RenderScene::Icon& icon : renderScene.icons) {
-            commandBuffer->BindMaterial({icon.texture->GetTexture()});
+            commandBuffer->BindMaterial({{icon.texture->GetTexture(), sampler}});
 
             for (const glm::vec3& position : icon.positions) {
                 RenderIcon(position);

--- a/src/Video/Renderer.hpp
+++ b/src/Video/Renderer.hpp
@@ -19,6 +19,7 @@ class GeometryBinding;
 class LowLevelRenderer;
 class CommandBuffer;
 class Texture;
+class Sampler;
 class ZBinning;
 class DebugDrawing;
 namespace Geometry {
@@ -129,6 +130,8 @@ class Renderer {
     Buffer* quadVertexBuffer;
     VertexDescription* quadVertexDescription;
     GeometryBinding* quadGeometryBinding;
+
+    const Sampler* sampler;
 
     // Icon rendering.
     Shader* iconVertexShader;

--- a/tests/Video/DrawTests.cpp
+++ b/tests/Video/DrawTests.cpp
@@ -270,6 +270,8 @@ bool DrawTexturedTriangle(void* data) {
     Texture2D* texture = new Texture2D(lowLevelRenderer, TEST_PNG, TEST_PNG_LENGTH);
     Texture2D* texture2 = new Texture2D(lowLevelRenderer, TEST_PNG, TEST_PNG_LENGTH);
 
+    const Sampler* sampler = lowLevelRenderer->GetSampler(Sampler::Filter::LINEAR, Sampler::Clamping::CLAMP_TO_EDGE);
+
     // Create command buffer.
     CommandBuffer* commandBuffer = lowLevelRenderer->CreateCommandBuffer();
 
@@ -278,7 +280,7 @@ bool DrawTexturedTriangle(void* data) {
     commandBuffer->BindGraphicsPipeline(graphicsPipeline);
     commandBuffer->SetViewportAndScissor(glm::uvec2(0, 0), glm::uvec2(imageSize, imageSize));
     commandBuffer->BindGeometry(geometryBinding);
-    commandBuffer->BindMaterial({ texture->GetTexture(), texture2->GetTexture() });
+    commandBuffer->BindMaterial({ {texture->GetTexture(), sampler}, {texture2->GetTexture(), sampler} });
     commandBuffer->Draw(3);
     commandBuffer->EndRenderPass();
 
@@ -766,6 +768,9 @@ bool InvertColors(void* data) {
     // Create geometry binding.
     GeometryBinding* triangleGeometryBinding = lowLevelRenderer->CreateGeometryBinding(triangleVertexDescription, triangleVertexBuffer);
 
+    // Get sampler.
+    const Sampler* sampler = lowLevelRenderer->GetSampler(Sampler::Filter::LINEAR, Sampler::Clamping::CLAMP_TO_EDGE);
+
     // Push constants.
     struct {
         glm::mat4 modelMatrix;
@@ -799,7 +804,7 @@ bool InvertColors(void* data) {
     commandBuffer->BeginRenderPass(secondColorTexture, RenderPass::LoadOperation::DONT_CARE);
     commandBuffer->BindGraphicsPipeline(invertGraphicsPipeline);
     commandBuffer->SetViewportAndScissor(glm::uvec2(0, 0), glm::uvec2(imageSize, imageSize));
-    commandBuffer->BindMaterial({ colorTexture });
+    commandBuffer->BindMaterial({ {colorTexture, sampler} });
     commandBuffer->Draw(3);
     commandBuffer->EndRenderPass();
 
@@ -894,6 +899,7 @@ bool DrawMipmappedTriangle(void* data) {
 
     // Create texture.
     Texture2D* texture = new Texture2D(lowLevelRenderer, TEST_PNG, TEST_PNG_LENGTH);
+    const Sampler* sampler = lowLevelRenderer->GetSampler(Sampler::Filter::LINEAR, Sampler::Clamping::CLAMP_TO_EDGE);
 
     // Create command buffer.
     CommandBuffer* commandBuffer = lowLevelRenderer->CreateCommandBuffer();
@@ -903,7 +909,7 @@ bool DrawMipmappedTriangle(void* data) {
     commandBuffer->BindGraphicsPipeline(graphicsPipeline);
     commandBuffer->SetViewportAndScissor(glm::uvec2(0, 0), glm::uvec2(imageSize, imageSize));
     commandBuffer->BindGeometry(geometryBinding);
-    commandBuffer->BindMaterial({ texture->GetTexture() });
+    commandBuffer->BindMaterial({ {texture->GetTexture(), sampler} });
     commandBuffer->Draw(3);
     commandBuffer->EndRenderPass();
 

--- a/tests/Video/SwapChainTests.cpp
+++ b/tests/Video/SwapChainTests.cpp
@@ -84,6 +84,7 @@ bool MultipleFrames(void* data) {
 
     // Create texture.
     Texture2D* texture = new Texture2D(lowLevelRenderer, TEST_PNG, TEST_PNG_LENGTH);
+    const Sampler* sampler = lowLevelRenderer->GetSampler(Sampler::Filter::LINEAR, Sampler::Clamping::CLAMP_TO_EDGE);
 
     // Create command buffer.
     CommandBuffer* commandBuffer = lowLevelRenderer->CreateCommandBuffer();
@@ -105,7 +106,7 @@ bool MultipleFrames(void* data) {
         commandBuffer->BindGraphicsPipeline(graphicsPipeline);
         commandBuffer->SetViewportAndScissor(glm::uvec2(0, 0), glm::uvec2(VideoSuite::swapchainSize, VideoSuite::swapchainSize));
         commandBuffer->BindGeometry(geometryBinding);
-        commandBuffer->BindMaterial({ texture->GetTexture() });
+        commandBuffer->BindMaterial({ {texture->GetTexture(), sampler} });
         commandBuffer->BindUniformBuffer(ShaderProgram::BindingType::MATRICES, uniformBuffer);
         const glm::mat4 modelMatrix = glm::translate(glm::mat4(), trianglePosition);
         commandBuffer->PushConstants(&modelMatrix);

--- a/tests/Video/shaders/DrawTexturedTriangle.frag
+++ b/tests/Video/shaders/DrawTexturedTriangle.frag
@@ -2,9 +2,9 @@ layout(location = 0) in vec2 texCoords;
 
 layout(location = 0) out vec4 outColor;
 
-MATERIAL(0, colorSampler)
-MATERIAL(1, alphaSampler)
+MATERIAL(0, colorTexture)
+MATERIAL(1, alphaTexture)
 
 void main() {
-    outColor = vec4(texture(colorSampler, texCoords).rgb, texture(alphaSampler, texCoords).a);
+    outColor = vec4(texture(colorTexture, texCoords).rgb, texture(alphaTexture, texCoords).a);
 }


### PR DESCRIPTION
Use separate sampler objects instead of keeping sampler state in the texture. This allows the same texture to be sampled in different ways, eg. to use different clamping when used as a texture or as a sprite.