### PR TITLE
Fix mesh debug drawing

### DIFF
--- a/src/Editor/Editor.cpp
+++ b/src/Editor/Editor.cpp
@@ -230,7 +230,7 @@ void Editor::Show(float deltaTime) {
             // Highlight selected.
             Component::Mesh* mesh = currentEntity->GetComponent<Component::Mesh>();
             if (mesh && mesh->geometry)
-                Managers().debugDrawingManager->AddMesh(mesh->entity->GetUniqueIdentifier(), mesh, mesh->entity->GetModelMatrix(), glm::vec3(0.2f, 0.72f, 0.2f));
+                Managers().debugDrawingManager->AddMesh(mesh, mesh->entity->GetModelMatrix(), glm::vec3(0.2f, 0.72f, 0.2f));
         }
     }
 }

--- a/src/Engine/Manager/DebugDrawingManager.hpp
+++ b/src/Engine/Manager/DebugDrawingManager.hpp
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <glm/glm.hpp>
-#include <map>
 #include <vector>
 #include <Video/DebugDrawing.hpp>
 
@@ -155,7 +154,6 @@ class DebugDrawingManager {
 
     /// Add a mesh to the world.
     /**
-     * @param id The entity's UID.
      * @param meshComponent The mesh component.
      * @param matrix Matrix to transform the mesh with.
      * @param color Color of the lines.
@@ -163,7 +161,7 @@ class DebugDrawingManager {
      * @param duration How long the mesh should stay in the world (in seconds).
      * @param depthTesting Whether to enable depth testing.
      */
-    void AddMesh(unsigned int id, Component::Mesh* meshComponent, const glm::mat4& matrix, const glm::vec3& color, bool wireFrame = true, float duration = 0.f, bool depthTesting = true);
+    void AddMesh(Component::Mesh* meshComponent, const glm::mat4& matrix, const glm::vec3& color, bool wireFrame = true, float duration = 0.f, bool depthTesting = true);
 
     /// Get all debug meshes.
     /**
@@ -191,5 +189,5 @@ class DebugDrawingManager {
     std::vector<Video::DebugDrawing::Sphere> spheres;
     std::vector<Video::DebugDrawing::Cylinder> cylinders;
     std::vector<Video::DebugDrawing::Cone> cones;
-    std::map<unsigned int, Video::DebugDrawing::Mesh> meshMap;
+    std::vector<Video::DebugDrawing::Mesh> meshes;
 };

--- a/src/Video/DebugDrawing.cpp
+++ b/src/Video/DebugDrawing.cpp
@@ -38,7 +38,7 @@ DebugDrawing::DebugDrawing(Renderer* renderer) {
     GraphicsPipeline::Configuration configuration = {};
     configuration.cullFace = CullFace::NONE;
     configuration.blendMode = BlendMode::NONE;
-    configuration.depthComparison = DepthComparison::LESS;
+    configuration.depthComparison = DepthComparison::LESS_EQUAL;
 
     for (uint8_t i = 0; i < 2; ++i) {
         configuration.depthMode = (i == 0 ? DepthMode::NONE : DepthMode::TEST_WRITE);

--- a/src/Video/DebugDrawing.hpp
+++ b/src/Video/DebugDrawing.hpp
@@ -196,9 +196,6 @@ class DebugDrawing {
 
     /// A debug drawing mesh.
     struct Mesh {
-        /// Reference count.
-        int referenceCount;
-
         /// The matrix used to transform the cone.
         glm::mat4 matrix;
 


### PR DESCRIPTION
The editor no longer crashes when selecting an entity that has a mesh.