### PR TITLE
wgpu backend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ docs/html
 
 # WebGPU backends
 externals/dawn
+externals/wgpu-native

--- a/docs/GettingStarted/Building/BuildingWebGPU.md
+++ b/docs/GettingStarted/Building/BuildingWebGPU.md
@@ -2,7 +2,8 @@
 
 Hymn to Beauty has an optional WebGPU backend. However, the goal is to support any WebGPU implementation, rather than mandating a specific one. Therefore, a WebGPU implementation is not included as part of the repository, so building with the WebGPU backend requires some additional steps.
 
-First, make sure you've followed all of the build instructions for the platform you're building for. Then follow the additional instructions for your chosen WebGPU backend. For now, only Dawn is supported.
+First, make sure you've followed all of the build instructions for the platform you're building for. Then follow the additional instructions for your chosen WebGPU backend.
 
-## Dawn
+## Backends
  - \subpage Dawn
+ - \subpage wgpu

--- a/docs/GettingStarted/Building/BuildingWebGPU/wgpu.md
+++ b/docs/GettingStarted/Building/BuildingWebGPU/wgpu.md
@@ -1,0 +1,62 @@
+\page wgpu
+
+## Installing dependencies
+Download and install the wgpu-native prerequisites described in the [docs](https://github.com/gfx-rs/wgpu-native/wiki/Getting-Started). You don't need the dependencies for the native examples.
+
+## Setting up wgpu
+Open a command prompt and navigate to the `externals` directory.
+
+### Download the wgpu-native source code
+```
+git clone https://github.com/gfx-rs/wgpu-native.git wgpu-native
+cd wgpu-native
+git submodule update --init
+```
+
+### Build wgpu-native
+```
+cargo update
+cargo build --release
+```
+
+## Building for Android
+You need NDK version 23 or newer.
+
+Navigate to the `externals/wgpu-native` directory.
+
+### Setup aarch64 target
+```
+rustup target add aarch64-linux-android
+```
+
+### Setup environment variables
+If you're using Windows as the host, run:
+```
+$env:BINDGEN_EXTRA_CLANG_ARGS="-isysroot NDK_DIRECTORY/toolchains/llvm/prebuilt/windows-x86_64/sysroot"
+$env:CLANG_PATH="NDK_DIRECTORY/toolchains/llvm/prebuilt/windows-x86_64/bin/aarch64-linux-android24-clang++.cmd"
+$env:CC=$env:CLANG_PATH
+$env:CXX=$env:CLANG_PATH
+$env:CARGO_TARGET_AARCH64_LINUX_ANDROID_LINKER=$env:CLANG_PATH
+```
+Replace `NDK_DIRECTORY` with the path to your NDK.
+
+If you're using Linux as the host, run:
+```
+export BINDGEN_EXTRA_CLANG_ARGS="-isysroot NDK_DIRECTORY/toolchains/llvm/prebuilt/linux-x86_64/sysroot"
+export CLANG_PATH="NDK_DIRECTORY/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android24-clang"
+export CC=$CLANG_PATH
+export CXX=$CLANG_PATH++
+export CARGO_TARGET_AARCH64_LINUX_ANDROID_LINKER=$CLANG_PATH
+```
+Replace `NDK_DIRECTORY` with the path to your NDK.
+
+### Build wgpu-native
+```
+cargo build --target aarch64-linux-android --release
+```
+
+## Configure Hymn to Beauty
+Configure Hymn to Beauty and enable the WebGPURenderer option.
+
+## Known issues
+Local lights will not currently work in wgpu due to missing atomics support.

--- a/externals/CMakeLists.txt
+++ b/externals/CMakeLists.txt
@@ -81,5 +81,37 @@ add_library(stb INTERFACE)
 target_include_directories(stb INTERFACE stb)
 
 if (WebGPURenderer)
-    add_subdirectory(dawn)
+    if (EXISTS "${CMAKE_CURRENT_LIST_DIR}/dawn")
+        message(VERBOSE "Using dawn as WebGPU backend")
+        add_subdirectory(dawn)
+        set(WEBGPU_BACKEND_DAWN ON PARENT_SCOPE)
+    elseif (EXISTS "${CMAKE_CURRENT_LIST_DIR}/wgpu-native")
+        message(VERBOSE "Using wgpu as WebGPU backend")
+        set(WEBGPU_BACKEND_WGPU ON PARENT_SCOPE)
+        
+        # Find library
+        if (ANDROID)
+            set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY BOTH)
+            find_library(WGPU_LIBRARY libwgpu_native.a wgpu_native
+                HINTS "${CMAKE_CURRENT_SOURCE_DIR}/wgpu-native/target/aarch64-linux-android/release"
+            )
+        else()
+            find_library(WGPU_LIBRARY wgpu_native
+                HINTS "${CMAKE_CURRENT_SOURCE_DIR}/wgpu-native/target/release"
+            )
+        endif()
+        
+        # Setup WebGPU headers.
+        add_library(wgpu_headers INTERFACE)
+        target_include_directories(wgpu_headers INTERFACE wgpu-native/ffi)
+        
+        # Dependencies
+        if(MSVC)
+            set(WGPU_OS_LIBRARIES "userenv" "ws2_32" "Dwmapi" "dbghelp" "d3dcompiler" "D3D12" "D3D11" "DXGI" "setupapi" "Bcrypt" PARENT_SCOPE)
+        elseif(APPLE)
+            set(WGPU_OS_LIBRARIES "-framework Cocoa" "-framework CoreVideo" "-framework IOKit" "-framework QuartzCore" PARENT_SCOPE)
+        endif()
+    else()
+        message(FATAL_ERROR "WebGPURenderer requested but no WebGPU backend found")
+    endif()
 endif()

--- a/src/Game/Android/app/build.gradle
+++ b/src/Game/Android/app/build.gradle
@@ -11,6 +11,10 @@ android {
         versionCode 272
         versionName "1.1.0"
 
+        ndk {
+            abiFilters 'arm64-v8a'
+        }
+
         externalNativeBuild {
             cmake {
                 arguments '-DVulkanRenderer=ON'

--- a/src/Video/CMakeLists.txt
+++ b/src/Video/CMakeLists.txt
@@ -58,16 +58,14 @@ set(HEADERS
     LowLevelRenderer/Interface/VertexDescription.hpp
 )
 
+add_library(Video STATIC)
+
 # Graphics API libraries to link to.
 set(API_LIBRARIES)
 
 if(OpenGLRenderer)
-    set(API_LIBRARIES
-        ${API_LIBRARIES}
-        glad
-    )
-
-    add_definitions(-DOPENGL_SUPPORT)
+    target_link_libraries(Video glad)
+    target_compile_definitions(Video PUBLIC OPENGL_SUPPORT)
 
     set(SRCS
         ${SRCS}
@@ -110,12 +108,9 @@ endif()
 
 if(VulkanRenderer)
     find_package(VULKAN REQUIRED)
-    set(API_LIBRARIES
-        ${API_LIBRARIES}
-        Vulkan::Vulkan
-    )
 
-    add_definitions(-DVULKAN_SUPPORT)
+    target_link_libraries(Video Vulkan::Vulkan)
+    target_compile_definitions(Video PUBLIC VULKAN_SUPPORT)
 
     set(SRCS
         ${SRCS}
@@ -159,13 +154,15 @@ if(VulkanRenderer)
 endif()
 
 if (WebGPURenderer)
-    set(API_LIBRARIES
-        ${API_LIBRARIES}
-        dawn_native
-        dawn_proc
-    )
+    if (WEBGPU_BACKEND_DAWN)
+        target_link_libraries(Video dawn_native dawn_proc)
+        target_compile_definitions(Video PUBLIC WEBGPU_BACKEND_DAWN)
+    elseif(WEBGPU_BACKEND_WGPU)
+        target_link_libraries(Video ${WGPU_LIBRARY} wgpu_headers ${WGPU_OS_LIBRARIES})
+        target_compile_definitions(Video PUBLIC WEBGPU_BACKEND_WGPU)
+    endif()
     
-    add_definitions(-DWEBGPU_SUPPORT)
+    target_compile_definitions(Video PUBLIC WEBGPU_SUPPORT)
     
     set(SRCS
         ${SRCS}
@@ -185,6 +182,7 @@ if (WebGPURenderer)
     
     set(HEADERS
         ${HEADERS}
+        LowLevelRenderer/WebGPU/WebGPU.hpp
         LowLevelRenderer/WebGPU/WebGPURenderer.hpp
         LowLevelRenderer/WebGPU/WebGPUBuffer.hpp
         LowLevelRenderer/WebGPU/WebGPUCommandBuffer.hpp
@@ -237,8 +235,8 @@ endforeach()
 
 create_directory_groups(${SRCS} ${HEADERS})
 
-add_library(Video STATIC ${SRCS} ${HEADERS} ${SHADER_SOURCE} ${SHADER_HEADER})
-target_link_libraries(Video Utility ${API_LIBRARIES} glm stb ShaderSource)
+target_sources(Video PRIVATE ${SRCS} ${HEADERS} ${SHADER_SOURCE} ${SHADER_HEADER})
+target_link_libraries(Video Utility glm stb ShaderSource)
 
 set_property(TARGET Video PROPERTY CXX_STANDARD 17)
 set_property(TARGET Video PROPERTY CXX_STANDARD_REQUIRED ON)

--- a/src/Video/LowLevelRenderer/Interface/LowLevelRenderer.hpp
+++ b/src/Video/LowLevelRenderer/Interface/LowLevelRenderer.hpp
@@ -42,6 +42,10 @@ class LowLevelRenderer {
 
         /// Bitmask of the number of MSAA samples supported for attachmentless rendering.
         uint32_t attachmentlessMsaaSamples;
+
+        /// Whether shaders can use atomics.
+        /// @todo Remove this once wgpu supports atomics.
+        bool shaderAtomics;
     };
 
     /// Create a new low-level renderer.

--- a/src/Video/LowLevelRenderer/OpenGL/OpenGLRenderer.cpp
+++ b/src/Video/LowLevelRenderer/OpenGL/OpenGLRenderer.cpp
@@ -72,6 +72,7 @@ OpenGLRenderer::OpenGLRenderer(Utility::Window* window) {
     optionalFeatures.wideLines = true;
     optionalFeatures.timestamps = precision > 0;
     optionalFeatures.conservativeRasterization = GLAD_GL_NV_conservative_raster;
+    optionalFeatures.shaderAtomics = true;
 
     assert(optionalFeatures.timestamps); /// @todo Disable GPU profiling if not supported.
 

--- a/src/Video/LowLevelRenderer/Vulkan/VulkanRenderer.cpp
+++ b/src/Video/LowLevelRenderer/Vulkan/VulkanRenderer.cpp
@@ -940,6 +940,8 @@ VkPhysicalDeviceFeatures VulkanRenderer::GetEnabledFeatures() {
 
     optionalFeatures.attachmentlessMsaaSamples = deviceProperties.limits.framebufferNoAttachmentsSampleCounts;
 
+    optionalFeatures.shaderAtomics = true;
+
     return enabledFeatures;
 }
 

--- a/src/Video/LowLevelRenderer/WebGPU/WebGPU.hpp
+++ b/src/Video/LowLevelRenderer/WebGPU/WebGPU.hpp
@@ -1,0 +1,37 @@
+#pragma once
+
+#if WEBGPU_BACKEND_DAWN
+#include <dawn/webgpu.h>
+
+/// @todo Remove after updating Dawn
+#define WGPUMipmapFilterMode_Nearest WGPUFilterMode_Nearest
+#define WGPUMipmapFilterMode_Linear WGPUFilterMode_Linear
+#endif
+
+#if WEBGPU_BACKEND_WGPU
+#include <wgpu.h>
+
+#define wgpuInstanceRelease wgpuInstanceDrop
+#define wgpuSurfaceRelease wgpuSurfaceDrop
+#define wgpuAdapterRelease wgpuAdapterDrop
+#define wgpuDeviceRelease wgpuDeviceDrop
+#define wgpuSwapChainRelease wgpuSwapChainDrop
+#define wgpuBufferRelease wgpuBufferDrop
+#define wgpuBindGroupRelease wgpuBindGroupDrop
+#define wgpuBindGroupLayoutRelease wgpuBindGroupLayoutDrop
+#define wgpuCommandEncoderRelease wgpuCommandEncoderDrop
+#define wgpuCommandBufferRelease wgpuCommandBufferDrop
+#define wgpuRenderPassEncoderRelease wgpuRenderPassEncoderDrop
+#define wgpuComputePassEncoderRelease wgpuComputePassEncoderDrop
+#define wgpuShaderModuleRelease wgpuShaderModuleDrop
+#define wgpuPipelineLayoutRelease wgpuPipelineLayoutDrop
+#define wgpuRenderPipelineRelease wgpuRenderPipelineDrop
+#define wgpuComputePipelineRelease wgpuComputePipelineDrop
+#define wgpuTextureRelease wgpuTextureDrop
+#define wgpuTextureViewRelease wgpuTextureViewDrop
+#define wgpuSamplerRelease wgpuSamplerDrop
+
+inline void wgpuDeviceTick(WGPUDevice device) {
+    wgpuDevicePoll(device, false, nullptr);
+}
+#endif

--- a/src/Video/LowLevelRenderer/WebGPU/WebGPUBuffer.hpp
+++ b/src/Video/LowLevelRenderer/WebGPU/WebGPUBuffer.hpp
@@ -2,7 +2,7 @@
 
 #include "../Interface/Buffer.hpp"
 
-#include <dawn/webgpu.h>
+#include "WebGPU.hpp"
 
 namespace Video {
 

--- a/src/Video/LowLevelRenderer/WebGPU/WebGPUCommandBuffer.hpp
+++ b/src/Video/LowLevelRenderer/WebGPU/WebGPUCommandBuffer.hpp
@@ -2,7 +2,7 @@
 
 #include "../Interface/CommandBuffer.hpp"
 
-#include <dawn/webgpu.h>
+#include "WebGPU.hpp"
 #include <vector>
 #include "WebGPUGraphicsPipeline.hpp"
 
@@ -110,6 +110,8 @@ class WebGPUCommandBuffer : public CommandBuffer {
     const WebGPUBuffer* currentUniformBuffer;
 
     WebGPUTexture* dummyRenderTarget = nullptr;
+
+    std::vector<WGPUBindGroup> bindGroupsToRelease;
 };
 
 } // namespace Video

--- a/src/Video/LowLevelRenderer/WebGPU/WebGPUComputePipeline.hpp
+++ b/src/Video/LowLevelRenderer/WebGPU/WebGPUComputePipeline.hpp
@@ -2,7 +2,7 @@
 
 #include "../Interface/ComputePipeline.hpp"
 
-#include <dawn/webgpu.h>
+#include "WebGPU.hpp"
 
 namespace Video {
 

--- a/src/Video/LowLevelRenderer/WebGPU/WebGPUGraphicsPipeline.hpp
+++ b/src/Video/LowLevelRenderer/WebGPU/WebGPUGraphicsPipeline.hpp
@@ -2,7 +2,7 @@
 
 #include "../Interface/GraphicsPipeline.hpp"
 
-#include <dawn/webgpu.h>
+#include "WebGPU.hpp"
 #include <map>
 
 namespace Video {

--- a/src/Video/LowLevelRenderer/WebGPU/WebGPURenderTargetAllocator.hpp
+++ b/src/Video/LowLevelRenderer/WebGPU/WebGPURenderTargetAllocator.hpp
@@ -2,7 +2,7 @@
 
 #include "../Interface/RenderTargetAllocator.hpp"
 
-#include <dawn/webgpu.h>
+#include "WebGPU.hpp"
 #include <map>
 #include <deque>
 

--- a/src/Video/LowLevelRenderer/WebGPU/WebGPURenderer.hpp
+++ b/src/Video/LowLevelRenderer/WebGPU/WebGPURenderer.hpp
@@ -2,7 +2,7 @@
 
 #include "../Interface/LowLevelRenderer.hpp"
 
-#include <dawn/webgpu.h>
+#include "WebGPU.hpp"
 #include <glm/glm.hpp>
 #include <vector>
 
@@ -93,6 +93,12 @@ class WebGPURenderer : public LowLevelRenderer {
      */
     bool HasDepthClipControl() const;
 
+    /// Get whether R11G11B10 render targets can be used.
+    /**
+     * @return Whether the device has rg11b10ufloat-renderable.
+     */
+    bool HasR11G11B10() const;
+
     /// Get the format of the swap chain.
     /**
      * @return The swap chain format.
@@ -140,6 +146,7 @@ class WebGPURenderer : public LowLevelRenderer {
     std::vector<Profiling::Event> finishedEvents;
 
     bool depthClipControlEnabled;
+    bool r11g11b10Enabled;
 };
 
 } // namespace Video

--- a/src/Video/LowLevelRenderer/WebGPU/WebGPUSampler.cpp
+++ b/src/Video/LowLevelRenderer/WebGPU/WebGPUSampler.cpp
@@ -18,12 +18,12 @@ WebGPUSampler::WebGPUSampler(WGPUDevice device, Filter filter, Clamping clamping
     case Filter::NEAREST:
         samplerDescriptor.magFilter = WGPUFilterMode_Nearest;
         samplerDescriptor.minFilter = WGPUFilterMode_Nearest;
-        samplerDescriptor.mipmapFilter = WGPUFilterMode_Nearest;
+        samplerDescriptor.mipmapFilter = WGPUMipmapFilterMode_Nearest;
         break;
     case Filter::LINEAR:
         samplerDescriptor.magFilter = WGPUFilterMode_Linear;
         samplerDescriptor.minFilter = WGPUFilterMode_Linear;
-        samplerDescriptor.mipmapFilter = WGPUFilterMode_Linear;
+        samplerDescriptor.mipmapFilter = WGPUMipmapFilterMode_Linear;
         break;
     default:
         assert(false);

--- a/src/Video/LowLevelRenderer/WebGPU/WebGPUSampler.hpp
+++ b/src/Video/LowLevelRenderer/WebGPU/WebGPUSampler.hpp
@@ -2,7 +2,7 @@
 
 #include "../Interface/Sampler.hpp"
 
-#include <dawn/webgpu.h>
+#include "WebGPU.hpp"
 
 namespace Video {
 

--- a/src/Video/LowLevelRenderer/WebGPU/WebGPUShader.hpp
+++ b/src/Video/LowLevelRenderer/WebGPU/WebGPUShader.hpp
@@ -2,7 +2,7 @@
 
 #include "../Interface/Shader.hpp"
 
-#include <dawn/webgpu.h>
+#include "WebGPU.hpp"
 #include <ShaderProcessor/ShaderSource.hpp>
 
 namespace Video {

--- a/src/Video/LowLevelRenderer/WebGPU/WebGPUShaderProgram.hpp
+++ b/src/Video/LowLevelRenderer/WebGPU/WebGPUShaderProgram.hpp
@@ -4,7 +4,7 @@
 
 #include <initializer_list>
 #include <vector>
-#include <dawn/webgpu.h>
+#include "WebGPU.hpp"
 
 namespace Video {
 

--- a/src/Video/LowLevelRenderer/WebGPU/WebGPUTexture.cpp
+++ b/src/Video/LowLevelRenderer/WebGPU/WebGPUTexture.cpp
@@ -52,7 +52,7 @@ WebGPUTexture::WebGPUTexture(WebGPURenderer& renderer, const glm::uvec2 size, Te
         break;
     case Texture::Format::R11G11B10:
         assert(type != Texture::Type::RENDER_DEPTH);
-        textureFormat = WGPUTextureFormat_RG11B10Ufloat;
+        textureFormat = renderer.HasR11G11B10() ? WGPUTextureFormat_RG11B10Ufloat : WGPUTextureFormat_RGBA16Float;
         break;
     case Texture::Format::R16G16B16A16:
         assert(type != Texture::Type::RENDER_DEPTH);
@@ -154,6 +154,8 @@ void WebGPUTexture::GenerateMipMaps(WebGPURenderer& renderer, const glm::uvec2& 
 
     // Get render target to render mips to. We'll reuse a single render target, rather than allocating a new one per mip, so it has to be the size of the largest mip we'll render.
     Texture* renderTarget = renderer.CreateRenderTarget(glm::uvec2(mipWidth, mipHeight), GetFormat());
+    WGPUBindGroup* textureBindGroups = new WGPUBindGroup[mipLevels];
+    WGPUTextureView* mipTextureViews = new WGPUTextureView[mipLevels];
 
     // Generate mipmaps.
     for (uint32_t i = 1; i < mipLevels; ++i) {
@@ -173,14 +175,14 @@ void WebGPUTexture::GenerateMipMaps(WebGPURenderer& renderer, const glm::uvec2& 
             textureViewDescriptor.baseArrayLayer = 0;
             textureViewDescriptor.arrayLayerCount = 1;
             textureViewDescriptor.aspect = WGPUTextureAspect_All;
-            WGPUTextureView mipTextureView = wgpuTextureCreateView(texture, &textureViewDescriptor);
+            mipTextureViews[i] = wgpuTextureCreateView(texture, &textureViewDescriptor);
 
             // Bind this texture view, and the sampler.
             WGPUBindGroupEntry entries[2];
 
             entries[0] = {};
             entries[0].binding = 0;
-            entries[0].textureView = mipTextureView;
+            entries[0].textureView = mipTextureViews[i];
 
             entries[1] = {};
             entries[1].binding = 1;
@@ -191,12 +193,9 @@ void WebGPUTexture::GenerateMipMaps(WebGPURenderer& renderer, const glm::uvec2& 
             bindGroupDescriptor.entryCount = 2;
             bindGroupDescriptor.entries = entries;
 
-            WGPUBindGroup textureBindGroup = wgpuDeviceCreateBindGroup(renderer.GetDevice(), &bindGroupDescriptor);
+            textureBindGroups[i] = wgpuDeviceCreateBindGroup(renderer.GetDevice(), &bindGroupDescriptor);
 
-            wgpuRenderPassEncoderSetBindGroup(commandBuffer->GetRenderPassEncoder(), ShaderProgram::BindingType::MATERIAL, textureBindGroup, 0, nullptr);
-
-            wgpuBindGroupRelease(textureBindGroup);
-            wgpuTextureViewRelease(mipTextureView);
+            wgpuRenderPassEncoderSetBindGroup(commandBuffer->GetRenderPassEncoder(), ShaderProgram::BindingType::MATERIAL, textureBindGroups[i], 0, nullptr);
         }
 
         commandBuffer->Draw(3, 0);
@@ -229,6 +228,15 @@ void WebGPUTexture::GenerateMipMaps(WebGPURenderer& renderer, const glm::uvec2& 
     }
 
     renderer.Submit(commandBuffer);
+
+    // Cleanup
+    for (uint32_t i = 1; i < mipLevels; ++i) {
+        wgpuBindGroupRelease(textureBindGroups[i]);
+        wgpuTextureViewRelease(mipTextureViews[i]);
+    }
+    delete[] textureBindGroups;
+    delete[] mipTextureViews;
+
     renderer.FreeRenderTarget(renderTarget);
 
     delete commandBuffer;

--- a/src/Video/LowLevelRenderer/WebGPU/WebGPUTexture.hpp
+++ b/src/Video/LowLevelRenderer/WebGPU/WebGPUTexture.hpp
@@ -3,7 +3,7 @@
 #include "../Interface/Texture.hpp"
 
 #include <glm/glm.hpp>
-#include <dawn/webgpu.h>
+#include "WebGPU.hpp"
 
 namespace Video {
 

--- a/src/Video/LowLevelRenderer/WebGPU/WebGPUVertexDescription.hpp
+++ b/src/Video/LowLevelRenderer/WebGPU/WebGPUVertexDescription.hpp
@@ -2,7 +2,7 @@
 
 #include "../Interface/VertexDescription.hpp"
 
-#include <dawn/webgpu.h>
+#include "WebGPU.hpp"
 
 namespace Video {
 

--- a/src/Video/shaders/DebugDrawing.frag
+++ b/src/Video/shaders/DebugDrawing.frag
@@ -1,12 +1,10 @@
 /*
 Fragment shader used for debug drawing.
 */
-layout(location = 0) in VertexData {
-    vec3 color;
-} vertexIn;
+layout(location = 0) in vec3 color;
 
 layout(location = 0) out vec4 outColor;
 
 void main() {
-    outColor = vec4(vertexIn.color, 1.0);
+    outColor = vec4(color, 1.0);
 }

--- a/src/Video/shaders/DebugDrawing.vert
+++ b/src/Video/shaders/DebugDrawing.vert
@@ -3,9 +3,7 @@ Vertex shader used for debug drawing.
 */
 layout(location = 0) in vec3 vertexPosition;
 
-layout(location = 0) out VertexData {
-    vec3 color;
-} vertexOut;
+layout(location = 0) out vec3 outColor;
 
 MATRICES
 {
@@ -20,9 +18,8 @@ PUSH_CONSTANTS
 
 void main () {
     gl_Position = matrices.viewProjectionMatrix * (pushConst.modelMatrix * vec4(vertexPosition, 1.0));
-    //gl_PointSize = pushConst.colorSize.z;
     
-    vertexOut.color = pushConst.colorSize.rgb;
+    outColor = pushConst.colorSize.rgb;
     
     FixPosition();
 }

--- a/src/Video/shaders/DebugDrawingPoint.vert
+++ b/src/Video/shaders/DebugDrawingPoint.vert
@@ -1,9 +1,7 @@
 /*
 Vertex shader used for debug drawing.
 */
-layout(location = 0) out VertexData {
-    vec3 color;
-} vertexOut;
+layout(location = 0) out vec3 outColor;
 
 MATRICES
 {
@@ -25,7 +23,7 @@ const vec2 relativePosition[6] = vec2[](
 void main () {
     gl_Position = matrices.viewProjectionMatrix * pushConst.position;
     
-    vertexOut.color = pushConst.colorSize.rgb;
+    outColor = pushConst.colorSize.rgb;
     
     FixPosition();
     

--- a/src/Video/shaders/Default3D.frag
+++ b/src/Video/shaders/Default3D.frag
@@ -3,12 +3,10 @@ Forward shader shading lights and applying effects
 */
 
 // --- IN ---
-layout(location = 0) in VertexData {
-    vec3 pos;
-    vec3 normal;
-    vec3 tangent;
-    vec2 texCoords;
-} vertexIn;
+layout(location = 0) in vec3 inPosition;
+layout(location = 1) in vec3 inNormal;
+layout(location = 2) in vec3 inTangent;
+layout(location = 3) in vec2 inTexCoords;
 
 // --- OUT ---
 layout(location = 0) out vec4 outColor;
@@ -221,11 +219,11 @@ vec3 ApplyLights(vec3 albedo, vec3 normal, float metallic, float roughness, vec3
 
 // --- MAIN ---
 void main() {
-    vec3 albedo = texture(mapAlbedo, vertexIn.texCoords).rgb;
+    vec3 albedo = texture(mapAlbedo, inTexCoords).rgb;
     albedo = pow(albedo, vec3(uniforms.gamma)); // Apply if texture not in sRGB
-    vec3 normal = calculateNormal(vertexIn.normal, vertexIn.tangent, texture(mapNormal, vertexIn.texCoords).rgb);
-    vec2 roughnessMetallic = texture(mapRoughnessMetallic, vertexIn.texCoords).gb;
-    vec3 pos = vertexIn.pos;
+    vec3 normal = calculateNormal(inNormal, inTangent, texture(mapNormal, inTexCoords).rgb);
+    vec2 roughnessMetallic = texture(mapRoughnessMetallic, inTexCoords).gb;
+    vec3 pos = inPosition;
 
     // Shade fragment.
     vec3 color = ApplyLights(albedo, normal, roughnessMetallic.r, roughnessMetallic.g, pos);

--- a/src/Video/shaders/Default3D.vert
+++ b/src/Video/shaders/Default3D.vert
@@ -6,12 +6,10 @@ layout(location = 1) in vec2 vertexTexture;
 layout(location = 2) in vec3 vertexNormal;
 layout(location = 3) in vec3 vertexTangent;
 
-layout(location = 0) out VertexData {
-    vec3 pos;
-    vec3 normal;
-    vec3 tangent;
-    vec2 texCoords;
-} vertexOut;
+layout(location = 0) out vec3 outPosition;
+layout(location = 1) out vec3 outNormal;
+layout(location = 2) out vec3 outTangent;
+layout(location = 3) out vec2 outTexCoords;
 
 MATRICES
 {
@@ -28,10 +26,10 @@ PUSH_CONSTANTS
 void main () {
     vec4 worldPosition = pushConst.modelMatrix * vec4(vertexPosition, 1.0);
     gl_Position = matrices.viewProjectionMatrix * worldPosition;
-    vertexOut.pos = vec3(matrices.viewMatrix * worldPosition);
-    vertexOut.normal = normalize(mat3(pushConst.normalMatrix) * vertexNormal);
-    vertexOut.tangent = vertexTangent;
-    vertexOut.texCoords = vertexTexture;
+    outPosition = vec3(matrices.viewMatrix * worldPosition);
+    outNormal = normalize(mat3(pushConst.normalMatrix) * vertexNormal);
+    outTangent = vertexTangent;
+    outTexCoords = vertexTexture;
     
     FixPosition();
 }

--- a/src/Video/shaders/EditorEntity.frag
+++ b/src/Video/shaders/EditorEntity.frag
@@ -1,14 +1,12 @@
 /*
 Textures editor entities.
 */
-layout(location = 0) in VertexData {
-    vec2 texCoords;
-} vertexIn;
+layout(location = 0) in vec2 texCoords;
 
 layout(location = 0) out vec4 outColor;
 
 MATERIAL(0, mapColor)
 
 void main () {
-    outColor = texture(mapColor, vertexIn.texCoords);
+    outColor = texture(mapColor, texCoords);
 }

--- a/src/Video/shaders/EditorEntity.vert
+++ b/src/Video/shaders/EditorEntity.vert
@@ -4,9 +4,7 @@ Vertex shader for editor entities.
 
 layout(location = 0) in vec2 vertexTexture;
 
-layout(location = 0) out VertexData {
-    vec2 texCoords;
-} vertexOut;
+layout(location = 0) out vec2 outTexCoords;
 
 MATRICES
 {
@@ -22,7 +20,7 @@ PUSH_CONSTANTS
 
 void main () {
     vec3 position = pushConst.position.xyz + pushConst.right.xyz * (vertexTexture.x - 0.5) - pushConst.up.xyz * (vertexTexture.y - 0.5);
-    vertexOut.texCoords = vertexTexture;
+    outTexCoords = vertexTexture;
     
     gl_Position = matrices.viewProjectionMatrix * vec4(position, 1.0);
     

--- a/src/Video/shaders/PostProcessing/BloomBlur.frag
+++ b/src/Video/shaders/PostProcessing/BloomBlur.frag
@@ -21,9 +21,12 @@ const float offsets[sampleCount] = float[](0.0, 1.386283, 3.253459);
 
 void main () {
     vec3 color = weights[0] * texture(colorSampler, inTexCoords).rgb;
-    for (int i = 1; i < sampleCount; i++) {
-        color += weights[i] * texture(colorSampler, inTexCoords + offsets[i] * pushConst.offset).rgb;
-        color += weights[i] * texture(colorSampler, inTexCoords - offsets[i] * pushConst.offset).rgb;
-    }
+    
+    color += weights[1] * texture(colorSampler, inTexCoords + offsets[1] * pushConst.offset).rgb;
+    color += weights[1] * texture(colorSampler, inTexCoords - offsets[1] * pushConst.offset).rgb;
+    
+    color += weights[2] * texture(colorSampler, inTexCoords + offsets[2] * pushConst.offset).rgb;
+    color += weights[2] * texture(colorSampler, inTexCoords - offsets[2] * pushConst.offset).rgb;
+    
     outColor = vec4(color, 1.0);
 }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -66,16 +66,6 @@ foreach(item ${IMAGES})
     ProcessWithHeaderize(IMAGES_HEADER IMAGES_SOURCE ${item} ${CMAKE_CURRENT_BINARY_DIR})
 endforeach()
 
-if(OpenGLRenderer)
-    add_definitions(-DOPENGL_SUPPORT)
-endif()
-if(VulkanRenderer)
-    add_definitions(-DVULKAN_SUPPORT)
-endif()
-if(WebGPURenderer)
-    add_definitions(-DWEBGPU_SUPPORT)
-endif()
-
 create_directory_groups(${SRCS} ${HEADERS})
 
 include_directories(../src)

--- a/tests/Video/VideoSuite.cpp
+++ b/tests/Video/VideoSuite.cpp
@@ -3,6 +3,7 @@
 #include <iostream>
 #include <Video/LowLevelRenderer/Interface/LowLevelRenderer.hpp>
 #include <Utility/Window.hpp>
+#include <Utility/Log.hpp>
 
 #ifdef OPENGL_SUPPORT
 #include <Video/LowLevelRenderer/OpenGL/OpenGLRenderer.hpp>
@@ -68,6 +69,8 @@ void VideoSuite::Init() {
         lowLevelRenderer = new Video::WebGPURenderer(window);
         break;
 #endif
+    default:
+        Log(Log::ERR) << "No backend selected/supported.\n";
     }
 }
 


### PR DESCRIPTION
Add the possibility of using wgpu as the WebGPU backend.

Due to limitations in Naga (lack of atomics), local lights are not currently rendered when using the wgpu backend.