### PR TITLE
Fix crash in WebGPU on Nvidia

### DIFF
--- a/src/Engine/Engine.cpp
+++ b/src/Engine/Engine.cpp
@@ -27,7 +27,7 @@ bool Engine::Start() {
     window = new Utility::Window(configuration.androidWindow);
 #else
     window = new Utility::Window(configuration.width, configuration.height, configuration.fullscreen, configuration.borderless, "Hymn to Beauty",
-                                 configuration.graphicsAPI == Video::Renderer::GraphicsAPI::VULKAN);
+                                 configuration.graphicsAPI == Video::Renderer::GraphicsAPI::VULKAN || configuration.graphicsAPI == Video::Renderer::GraphicsAPI::WEBGPU);
 #endif
 
     Input::GetInstance().SetWindow(window);


### PR DESCRIPTION
Use GLFW_NO_API when creating window for WebGPU. Without this window hint, using a Vulkan backend of Dawn or wgpu crashes on Nvidia.