### PR TITLE
Optimize model matrix calculations

### DIFF
--- a/docs/ScriptingReference/ClassReference.md
+++ b/docs/ScriptingReference/ClassReference.md
@@ -39,6 +39,42 @@ Get child based on its index in child array. Returns null if no child with that 
 `uint GetNumChildren() const`  
 Get the number of children the entity has.
 
+`const vec3& GetPosition() const`  
+Get the position in local space.
+
+`void SetPosition(const vec3& position)`  
+Set the position in local space.
+
+`vec3 GetWorldPosition() const`  
+Get the position in world space.
+
+`void SetWorldPosition(const vec3& position)`  
+Set the position in world space.
+
+`void Move(const vec3& translation)`  
+Move in local space.
+
+`const vec3& GetScale() const`  
+Get the scale in local space.
+
+`void SetScale(const vec3& scale)`  
+Set the scale in local space.
+
+`const quat& GetRotation() const`  
+Get the rotation in local space.
+
+`void SetRotation(const quat& rotation)`  
+Set the rotation in local space.
+
+`quat GetWorldRotation()`  
+Get the rotation in world space.
+
+`void SetWorldRotation(const quat& rotation)`  
+Set the rotation in world space.
+
+`void RotateAroundWorldAxis(float angle, const vec3& axis)`  
+Rotate quaternion style.
+
 `void RotateYaw(float angle)`  
 Rotate the entity around the Y axis.
 
@@ -47,15 +83,6 @@ Rotate the entity around the X axis.
 
 `void RotateRoll(float angle)`  
 Rotate the entity around the Z axis.
-
-`void RotateAroundWorldAxis(float angle, const vec3& axis)`  
-Rotate quaternion style.
-
-`void SetWorldOrientation(quat orientation)`  
-Set the orientation in world space.
-
-`void SetLocalOrientation(quat orientation)`  
-Set the orientation in local space.
 
 `Component::DirectionalLight@ GetDirectionalLight()`  
 Get the entity's directional light component, if it has any. Otherwise returns null.
@@ -87,15 +114,6 @@ Get the entity's sprite component, if it has any. Otherwise returns null.
 ## Properties
 `string name`  
 The name of the entity.
-
-`vec3 position`  
-Position relative to the parent entity.
-
-`vec3 scale`  
-Scale.
-
-`quat rotation`  
-Rotation.
 
 \section DirectionalLight Component::DirectionalLight
 A light that is infinitely far away and thus casts parallel rays. Like the sun.

--- a/src/Editor/GUI/Editors/EntityEditor.cpp
+++ b/src/Editor/GUI/Editors/EntityEditor.cpp
@@ -83,48 +83,55 @@ void EntityEditor::Show() {
         ImGui::InputText("Name", name, 128);
         entity->name = name;
         ImGui::Text("Transform");
-        ImGui::ShowHelpMarker("The entity's position, rotation and scale.", 75.f);
+        ImGui::ShowHelpMarker("The entity's position, rotation and scale.", 75.0f);
         ImGui::Indent();
+
+        position = entity->GetPosition();
 
         if (EditorSettings::GetInstance().GetBool("Grid Snap")) {
             int toNearest = EditorSettings::GetInstance().GetLong("Grid Snap Size");
 
-            int value = static_cast<unsigned int>(entity->position.x);
+            int value = static_cast<unsigned int>(position.x);
             int rest = value % toNearest;
 
             if (rest > (toNearest / 2)) {
-                entity->position.x = static_cast<float>((value - rest) + toNearest);
+                position.x = static_cast<float>((value - rest) + toNearest);
             } else {
-                entity->position.x = static_cast<float>(value - rest);
+                position.x = static_cast<float>(value - rest);
             }
 
-            value = static_cast<int>(entity->position.y);
+            value = static_cast<int>(position.y);
             rest = value % toNearest;
 
             if (rest > (toNearest / 2)) {
-                entity->position.y = static_cast<float>((value - rest) + toNearest);
+                position.y = static_cast<float>((value - rest) + toNearest);
             } else {
-                entity->position.y = static_cast<float>((value - rest));
+                position.y = static_cast<float>((value - rest));
             }
 
-            value = static_cast<int>(entity->position.z);
+            value = static_cast<int>(position.z);
             rest = value % toNearest;
 
             if (rest > (toNearest / 2)) {
-                entity->position.z = static_cast<float>((value - rest) + toNearest);
+                position.z = static_cast<float>((value - rest) + toNearest);
             } else {
-                entity->position.z = static_cast<float>(value - rest);
+                position.z = static_cast<float>(value - rest);
             }
         }
 
-        ImGui::DraggableVec3("Position", entity->position);
+        ImGui::DraggableVec3("Position", position);
+        entity->SetPosition(position);
 
-        glm::vec3 eulerAngles = glm::eulerAngles(entity->rotation);
+        glm::vec3 eulerAngles = glm::eulerAngles(entity->GetRotation());
         eulerAngles = glm::degrees(eulerAngles);
-        if (ImGui::InputFloat3("Euler angles", &eulerAngles.x))
-            entity->SetLocalOrientation(glm::quat(glm::radians(eulerAngles)));
+        if (ImGui::InputFloat3("Euler angles", &eulerAngles.x)) {
+            entity->SetRotation(glm::quat(glm::radians(eulerAngles)));
+        }
 
-        ImGui::DraggableVec3("Scale", entity->scale);
+        scale = entity->GetScale();
+        ImGui::DraggableVec3("Scale", scale);
+        entity->SetScale(scale);
+
         ImGui::Text("Unique Identifier: %u", entity->GetUniqueIdentifier());
         ImGui::Unindent();
         if (!entity->IsScene()) {
@@ -154,6 +161,8 @@ void EntityEditor::Show() {
 void EntityEditor::SetEntity(Entity* entity) {
     this->entity = entity;
     strcpy(name, entity->name.c_str());
+    position = entity->GetPosition();
+    scale = entity->GetScale();
 
     auto shapeComp = this->entity->GetComponent<Component::Shape>();
     if (shapeComp != nullptr) {

--- a/src/Editor/GUI/Editors/EntityEditor.hpp
+++ b/src/Editor/GUI/Editors/EntityEditor.hpp
@@ -96,6 +96,8 @@ class EntityEditor {
     bool visible = false;
     char name[128];
     char stringPropertyBuffer[128];
+    glm::vec3 position;
+    glm::vec3 scale;
 
     struct Editor {
         std::function<void()> addFunction;

--- a/src/Editor/Util/GLTFImporter.cpp
+++ b/src/Editor/Util/GLTFImporter.cpp
@@ -528,24 +528,30 @@ void GLTFImporter::LoadNode(GLTF& gltf, Entity* parent, uint32_t index) {
 
     // Translation.
     if (node["translation"] != Json::nullValue) {
-        entity->position.x = node["translation"][0].asFloat();
-        entity->position.y = node["translation"][1].asFloat();
-        entity->position.z = node["translation"][2].asFloat();
+        entity->SetPosition(glm::vec3(
+            node["translation"][0].asFloat(),
+            node["translation"][1].asFloat(),
+            node["translation"][2].asFloat()
+        ));
     }
 
     // Rotation.
     if (node["rotation"] != Json::nullValue) {
-        entity->rotation.x = node["rotation"][0].asFloat();
-        entity->rotation.y = node["rotation"][1].asFloat();
-        entity->rotation.z = node["rotation"][2].asFloat();
-        entity->rotation.w = node["rotation"][3].asFloat();
+        entity->SetRotation(glm::quat(
+            node["rotation"][3].asFloat(),
+            node["rotation"][0].asFloat(),
+            node["rotation"][1].asFloat(),
+            node["rotation"][2].asFloat()
+        ));
     }
 
     // Scale.
     if (node["scale"] != Json::nullValue) {
-        entity->scale.x = node["scale"][0].asFloat();
-        entity->scale.y = node["scale"][1].asFloat();
-        entity->scale.z = node["scale"][2].asFloat();
+        entity->SetScale(glm::vec3(
+            node["scale"][0].asFloat(),
+            node["scale"][1].asFloat(),
+            node["scale"][2].asFloat()
+        ));
     }
 
     /// @todo Matrix.

--- a/src/Engine/Manager/PhysicsManager.cpp
+++ b/src/Engine/Manager/PhysicsManager.cpp
@@ -54,7 +54,7 @@ void PhysicsManager::Update(float deltaTime) {
         }
 
         auto worldPos = rigidBodyComp->entity->GetWorldPosition();
-        auto worldOrientation = rigidBodyComp->entity->GetWorldOrientation();
+        auto worldOrientation = rigidBodyComp->entity->GetWorldRotation();
         if (rigidBodyComp->ghost) {
             rigidBodyComp->SetPosition(worldPos);
             rigidBodyComp->SetOrientation(worldOrientation);
@@ -100,7 +100,7 @@ void PhysicsManager::UpdateEntityTransforms() {
         auto trans = rigidBodyComp->GetBulletRigidBody()->getWorldTransform();
         if (!rigidBodyComp->ghost && !rigidBodyComp->IsKinematic()) {
             entity->SetWorldPosition(Physics::btToGlm(trans.getOrigin()));
-            entity->SetWorldOrientation(Physics::btToGlm(trans.getRotation()));
+            entity->SetWorldRotation(Physics::btToGlm(trans.getRotation()));
         }
     }
 }

--- a/src/Engine/Manager/RenderManager.cpp
+++ b/src/Engine/Manager/RenderManager.cpp
@@ -161,7 +161,7 @@ void RenderManager::AddCamera(Video::RenderScene& renderScene, const Component::
 
     Entity* cameraEntity = camera.entity;
     renderCamera.position = cameraEntity->GetWorldPosition();
-    renderCamera.viewMatrix = glm::inverse(cameraEntity->GetModelMatrix());
+    renderCamera.viewMatrix = glm::inverse(cameraEntity->GetWorldModelMatrix());
     renderCamera.projectionMatrix = camera.GetProjection(glm::vec2(windowSize) * glm::vec2(camera.viewport.z, camera.viewport.w));
     renderCamera.viewProjectionMatrix = renderCamera.projectionMatrix * renderCamera.viewMatrix;
     renderCamera.zNear = camera.zNear;
@@ -217,7 +217,7 @@ void RenderManager::AddWorldLights(Video::RenderScene& renderScene, bool showLig
         Video::RenderScene::DirectionalLight light;
 
         Entity* lightEntity = directionalLight->entity;
-        light.direction = lightEntity->GetDirection();
+        light.direction = lightEntity->GetWorldDirection();
         light.color = directionalLight->color;
         light.ambientCoefficient = directionalLight->ambientCoefficient;
 
@@ -237,7 +237,7 @@ void RenderManager::AddWorldLights(Video::RenderScene& renderScene, bool showLig
         light.color = spotLight->color;
         light.intensity = spotLight->intensity;
         light.attenuation = spotLight->attenuation;
-        light.direction = lightEntity->GetDirection();
+        light.direction = lightEntity->GetWorldDirection();
         light.coneAngle = spotLight->coneAngle;
 
         renderScene.spotLights.push_back(light);
@@ -292,7 +292,7 @@ void RenderManager::AddMeshes(Video::RenderScene& renderScene) {
             continue;
 
         Video::RenderScene::Mesh mesh;
-        mesh.modelMatrix = entity->GetModelMatrix();
+        mesh.modelMatrix = entity->GetWorldModelMatrix();
         mesh.geometry = meshComp->model;
         mesh.axisAlignedBoundingBox = meshComp->model->GetAxisAlignedBoundingBox();
         mesh.albedo = material->albedo->GetTexture();
@@ -357,22 +357,22 @@ void RenderManager::AddEditorEntities(Video::RenderScene& renderScene, const Deb
             if (shape.GetKind() == ::Physics::Shape::Kind::Sphere) {
                 Managers().debugDrawingManager->AddSphere(shapeComp->entity->GetWorldPosition(), shape.GetSphereData()->radius, glm::vec3(1.0f, 1.0f, 1.0f));
             } else if (shape.GetKind() == ::Physics::Shape::Kind::Plane) {
-                glm::vec3 normal = shapeComp->entity->GetModelMatrix() * glm::vec4(shape.GetPlaneData()->normal, 0.0f);
+                glm::vec3 normal = shapeComp->entity->GetWorldModelMatrix() * glm::vec4(shape.GetPlaneData()->normal, 0.0f);
                 Managers().debugDrawingManager->AddPlane(shapeComp->entity->GetWorldPosition(), normal, glm::vec2(1.0f, 1.0f), glm::vec3(1.0f, 1.0f, 1.0f));
             } else if (shape.GetKind() == ::Physics::Shape::Kind::Box) {
                 glm::vec3 dimensions(shape.GetBoxData()->width, shape.GetBoxData()->height, shape.GetBoxData()->depth);
                 glm::vec3 position = shapeComp->entity->GetWorldPosition();
-                glm::quat orientation = shapeComp->entity->GetWorldOrientation();
+                glm::quat orientation = shapeComp->entity->GetWorldRotation();
                 glm::mat4 transformationMatrix = glm::translate(glm::mat4(), position) * glm::toMat4(orientation);
                 Managers().debugDrawingManager->AddCuboid(dimensions, transformationMatrix, glm::vec3(1.0f, 1.0f, 1.0f));
             } else if (shape.GetKind() == ::Physics::Shape::Kind::Cylinder) {
                 glm::vec3 position = shapeComp->entity->GetWorldPosition();
-                glm::quat orientation = shapeComp->entity->GetWorldOrientation();
+                glm::quat orientation = shapeComp->entity->GetWorldRotation();
                 glm::mat4 transformationMatrix = glm::translate(glm::mat4(), position) * glm::toMat4(orientation);
                 Managers().debugDrawingManager->AddCylinder(shape.GetCylinderData()->radius, shape.GetCylinderData()->length, transformationMatrix, glm::vec3(1.0f, 1.0f, 1.0f));
             } else if (shape.GetKind() == ::Physics::Shape::Kind::Cone) {
                 glm::vec3 position = shapeComp->entity->GetWorldPosition();
-                glm::quat orientation = shapeComp->entity->GetWorldOrientation();
+                glm::quat orientation = shapeComp->entity->GetWorldRotation();
                 glm::mat4 transformationMatrix = glm::translate(glm::mat4(), position) * glm::toMat4(orientation);
                 Managers().debugDrawingManager->AddCone(shape.GetConeData()->radius, shape.GetConeData()->height, transformationMatrix, glm::vec3(1.0f, 1.0f, 1.0f));
             }
@@ -402,7 +402,7 @@ void RenderManager::AddSprites(Video::RenderScene& renderScene) {
 
         Video::RenderScene::Sprite sprite;
         sprite.texture = spriteComp->texture->GetTexture();
-        sprite.modelMatrix = entity->GetModelMatrix();
+        sprite.modelMatrix = entity->GetWorldModelMatrix();
         sprite.size = glm::vec2(sprite.texture->GetTexture()->GetSize()) / spriteComp->pixelsPerUnit;
         sprite.pivot = spriteComp->pivot;
         sprite.tint = glm::vec4(spriteComp->tint, spriteComp->alpha);

--- a/src/Engine/Manager/ScriptManager.cpp
+++ b/src/Engine/Manager/ScriptManager.cpp
@@ -353,11 +353,6 @@ ScriptManager::ScriptManager(Utility::Window* window) {
     // Register Entity.
     engine->RegisterObjectType("Entity", 0, asOBJ_REF | asOBJ_NOCOUNT);
     engine->RegisterObjectProperty("Entity", "string name", asOFFSET(Entity, name));
-    engine->RegisterObjectProperty("Entity", "quat rotation", asOFFSET(Entity, rotation));
-    engine->RegisterObjectProperty("Entity", "vec3 position", asOFFSET(Entity, position));
-    engine->RegisterObjectProperty("Entity", "vec3 scale", asOFFSET(Entity, scale));
-    engine->RegisterObjectMethod("Entity", "vec3 GetWorldPosition() const", asMETHOD(Entity, GetWorldPosition), asCALL_THISCALL);
-    engine->RegisterObjectMethod("Entity", "void SetWorldPosition(const vec3 &in)", asMETHOD(Entity, SetWorldPosition), asCALL_THISCALL);
     engine->RegisterObjectMethod("Entity", "void Kill()", asMETHOD(Entity, Kill), asCALL_THISCALL);
     engine->RegisterObjectMethod("Entity", "bool IsKilled() const", asMETHOD(Entity, IsKilled), asCALL_THISCALL);
     engine->RegisterObjectMethod("Entity", "void SetEnabled(bool, bool)", asMETHOD(Entity, SetEnabled), asCALL_THISCALL);
@@ -372,14 +367,25 @@ ScriptManager::ScriptManager(Utility::Window* window) {
 
     engine->RegisterGlobalFunction("Entity@ GetEntityByGUID(uint GUID)", asFUNCTIONPR(ActiveHymn::GetEntityByGUID, (unsigned int), Entity*), asCALL_CDECL);
 
+    engine->RegisterObjectMethod("Entity", "const vec3& GetPosition() const", asMETHOD(Entity, GetPosition), asCALL_THISCALL);
+    engine->RegisterObjectMethod("Entity", "void SetPosition(const vec3 &in)", asMETHOD(Entity, SetPosition), asCALL_THISCALL);
+    engine->RegisterObjectMethod("Entity", "vec3 GetWorldPosition() const", asMETHOD(Entity, GetWorldPosition), asCALL_THISCALL);
+    engine->RegisterObjectMethod("Entity", "void SetWorldPosition(const vec3 &in)", asMETHOD(Entity, SetWorldPosition), asCALL_THISCALL);
+    engine->RegisterObjectMethod("Entity", "void Move(const vec3 &in)", asMETHOD(Entity, Move), asCALL_THISCALL);
+
+    engine->RegisterObjectMethod("Entity", "const vec3& GetScale() const", asMETHOD(Entity, GetScale), asCALL_THISCALL);
+    engine->RegisterObjectMethod("Entity", "void SetScale(const vec3 &in)", asMETHOD(Entity, SetScale), asCALL_THISCALL);
+
+    engine->RegisterObjectMethod("Entity", "const quat& GetRotation() const", asMETHOD(Entity, GetRotation), asCALL_THISCALL);
+    engine->RegisterObjectMethod("Entity", "void SetRotation(const quat& in)", asMETHOD(Entity, SetRotation), asCALL_THISCALL);
+    engine->RegisterObjectMethod("Entity", "quat GetWorldRotation()", asMETHOD(Entity, GetWorldRotation), asCALL_THISCALL);
+    engine->RegisterObjectMethod("Entity", "void SetWorldRotation(const quat& in)", asMETHOD(Entity, SetWorldRotation), asCALL_THISCALL);
+    engine->RegisterObjectMethod("Entity", "void RotateAroundWorldAxis(float, const vec3 &in)", asMETHOD(Entity, RotateAroundWorldAxis), asCALL_THISCALL);
     engine->RegisterObjectMethod("Entity", "void RotateYaw(float angle)", asMETHOD(Entity, RotateYaw), asCALL_THISCALL);
     engine->RegisterObjectMethod("Entity", "void RotatePitch(float angle)", asMETHOD(Entity, RotatePitch), asCALL_THISCALL);
     engine->RegisterObjectMethod("Entity", "void RotateRoll(float angle)", asMETHOD(Entity, RotateRoll), asCALL_THISCALL);
-    engine->RegisterObjectMethod("Entity", "void RotateAroundWorldAxis(float, const vec3 &in)", asMETHOD(Entity, RotateAroundWorldAxis), asCALL_THISCALL);
-    engine->RegisterObjectMethod("Entity", "quat GetWorldOrientation()", asMETHOD(Entity, GetWorldOrientation), asCALL_THISCALL);
-    engine->RegisterObjectMethod("Entity", "void SetWorldOrientation(const quat& in)", asMETHOD(Entity, SetWorldOrientation), asCALL_THISCALL);
-    engine->RegisterObjectMethod("Entity", "void SetLocalOrientation(const quat& in)", asMETHOD(Entity, SetLocalOrientation), asCALL_THISCALL);
-    engine->RegisterObjectMethod("Entity", "Entity@ SetParent(Entity@ parent) const", asMETHOD(Entity, SetParent), asCALL_THISCALL);
+
+    engine->RegisterObjectMethod("Entity", "Entity@ SetParent(Entity@ parent)", asMETHOD(Entity, SetParent), asCALL_THISCALL);
 
     // Register components.
     engine->SetDefaultNamespace("Component");
@@ -948,7 +954,7 @@ bool ScriptManager::IsIntersect(Entity* checker, Entity* camera) const {
     RayIntersection rayIntersector;
     float intersectDistance;
     const glm::vec3 rayDirection = MousePicking::GetRayDirection(camera, projection, window);
-    if (rayIntersector.RayOBBIntersect(camera->GetWorldPosition(), rayDirection, checker->GetComponent<Component::Mesh>()->model->GetAxisAlignedBoundingBox(), checker->GetModelMatrix(), intersectDistance)) {
+    if (rayIntersector.RayOBBIntersect(camera->GetWorldPosition(), rayDirection, checker->GetComponent<Component::Mesh>()->model->GetAxisAlignedBoundingBox(), checker->GetWorldModelMatrix(), intersectDistance)) {
         if (intersectDistance < 10.0f)
             return true;
         return false;

--- a/src/Engine/Manager/SoundManager.cpp
+++ b/src/Engine/Manager/SoundManager.cpp
@@ -52,7 +52,7 @@ void SoundManager::Update() {
         }
 
         // Set position.
-        glm::vec3 position = glm::vec3(entity->GetModelMatrix() * glm::vec4(0.0f, 0.0f, 0.0f, 1.0f));
+        glm::vec3 position = entity->GetWorldPosition();
         ma_sound_set_position(&sound->sound, position.x, position.y, position.z);
 
         /// @todo Set velocity based on physics.
@@ -74,11 +74,11 @@ void SoundManager::Update() {
         Entity* entity = listener->entity;
 
         // Set position
-        glm::vec3 position = entity->position;
+        glm::vec3 position = entity->GetWorldPosition();
         ma_engine_listener_set_position(&engine, 0, position.x, position.y, position.z);
 
         // Set orientation.
-        glm::quat orientation = entity->GetWorldOrientation();
+        glm::quat orientation = entity->GetWorldRotation();
         glm::vec3 forward = orientation * glm::vec3(0.0f, 0.0f, -1.0f);
         glm::vec3 up = orientation * glm::vec3(0.0f, 1.0f, 0.0f);
         ma_engine_listener_set_direction(&engine, 0, forward.x, forward.y, forward.z);

--- a/src/Engine/Util/MousePicking.cpp
+++ b/src/Engine/Util/MousePicking.cpp
@@ -32,7 +32,7 @@ static glm::vec3 ConvertWorldCoords(const glm::vec4& eyeCoords, const glm::mat4&
 }
 
 glm::vec3 GetRayDirection(const Entity* camera, const glm::mat4& projection, const Utility::Window* window) {
-    const glm::mat4 viewMatrix = glm::inverse(camera->GetModelMatrix());
+    const glm::mat4 viewMatrix = glm::inverse(camera->GetWorldModelMatrix());
     double mouseX = Managers().inputManager->GetCursorX();
     double mouseY = Managers().inputManager->GetCursorY();
 


### PR DESCRIPTION
Write a specialized function to get the model matrix directly instead of calculating matrices for scaling, rotation and translation independently and then multiplying them together. Also cache matrices and only update them if they are dirty.

In a Sponza test scene, measured on an AMD Ryzen 5 2600X, setting up the render scene goes from ~0.32 ms to ~0.10 ms.
On a Samsung Galaxy S21 (Exynos), the same scene goes from ~12.06 ms to ~0.12 ms.