### PR TITLE
Optimize WebGPU buffer allocation

### DIFF
--- a/src/Video/CMakeLists.txt
+++ b/src/Video/CMakeLists.txt
@@ -168,6 +168,7 @@ if (WebGPURenderer)
         ${SRCS}
         LowLevelRenderer/WebGPU/WebGPURenderer.cpp
         LowLevelRenderer/WebGPU/WebGPUBuffer.cpp
+        LowLevelRenderer/WebGPU/WebGPUBufferAllocator.cpp
         LowLevelRenderer/WebGPU/WebGPUCommandBuffer.cpp
         LowLevelRenderer/WebGPU/WebGPUComputePipeline.cpp
         LowLevelRenderer/WebGPU/WebGPUGeometryBinding.cpp
@@ -185,6 +186,7 @@ if (WebGPURenderer)
         LowLevelRenderer/WebGPU/WebGPU.hpp
         LowLevelRenderer/WebGPU/WebGPURenderer.hpp
         LowLevelRenderer/WebGPU/WebGPUBuffer.hpp
+        LowLevelRenderer/WebGPU/WebGPUBufferAllocator.hpp
         LowLevelRenderer/WebGPU/WebGPUCommandBuffer.hpp
         LowLevelRenderer/WebGPU/WebGPUComputePipeline.hpp
         LowLevelRenderer/WebGPU/WebGPUGeometryBinding.hpp

--- a/src/Video/LowLevelRenderer/WebGPU/WebGPUBuffer.cpp
+++ b/src/Video/LowLevelRenderer/WebGPU/WebGPUBuffer.cpp
@@ -1,65 +1,29 @@
 #include "WebGPUBuffer.hpp"
 
+#include "WebGPUBufferAllocator.hpp"
 #include <Utility/Log.hpp>
 #include <cstring>
 
 namespace Video {
 
-WebGPUBuffer::WebGPUBuffer(WGPUDevice device, Buffer::BufferUsage bufferUsage, uint32_t size, const void* data) : Buffer(bufferUsage) {
-    WGPUBufferDescriptor bufferDescriptor = {};
-    switch (bufferUsage) {
-    case Buffer::BufferUsage::VERTEX_BUFFER:
-        bufferDescriptor.usage = WGPUBufferUsage_Vertex;
-        break;
-    case Buffer::BufferUsage::INDEX_BUFFER:
-        bufferDescriptor.usage = WGPUBufferUsage_Index;
-        break;
-    case Buffer::BufferUsage::UNIFORM_BUFFER:
-        bufferDescriptor.usage = WGPUBufferUsage_Uniform | WGPUBufferUsage_CopyDst;
-        // Buffer binding sizes must be a multiple of 16.
-        size = (size + 16 - 1) / 16 * 16;
-        break;
-    case Buffer::BufferUsage::STORAGE_BUFFER:
-        bufferDescriptor.usage = WGPUBufferUsage_Storage | WGPUBufferUsage_CopyDst;
-        // Buffer binding sizes must be a multiple of 16.
-        size = (size + 16 - 1) / 16 * 16;
-        break;
-    case Buffer::BufferUsage::VERTEX_STORAGE_BUFFER:
-        bufferDescriptor.usage = WGPUBufferUsage_Vertex | WGPUBufferUsage_Storage | WGPUBufferUsage_CopyDst;
-        // Buffer binding sizes must be a multiple of 16.
-        size = (size + 16 - 1) / 16 * 16;
-        break;
-    }
-
-    if (data != nullptr) {
-        // We are allowed to set mappedAtCreation even without MAP_READ or MAP_WRITE usage flags. This allows us to initialize the buffer with data.
-        bufferDescriptor.mappedAtCreation = true;
-
-        // Buffers that are mapped at creation must have a size that is a multiple of 4.
-        size = (size + 4 - 1) / 4 * 4;
-    }
-
-    this->size = size;
-    bufferDescriptor.size = size;
-
-    buffer = wgpuDeviceCreateBuffer(device, &bufferDescriptor);
-
-    if (data != nullptr) {
-        // Copy the initial data.
-        void* mappedData = wgpuBufferGetMappedRange(buffer, 0, size);
-        memcpy(mappedData, data, size);
-        wgpuBufferUnmap(buffer);
-    }
+WebGPUBuffer::WebGPUBuffer(Buffer::BufferUsage bufferUsage, const BufferAllocation& allocation) : Buffer(bufferUsage) {
+    Reset(bufferUsage, allocation);
 }
 
 WebGPUBuffer::~WebGPUBuffer() {
-    wgpuBufferRelease(buffer);
+    if (!temporaryAllocation) {
+        delete rawBuffer;
+    }
 }
 
 void WebGPUBuffer::Reset(BufferUsage bufferUsage, const BufferAllocation& allocation) {
-    assert(false);
-
-    Log(Log::ERR) << "WebGPUBuffer::Reset should never be called.\n";
+    this->bufferUsage = bufferUsage;
+    rawBuffer = allocation.buffer;
+    WebGPURawBuffer* webGPURawBuffer = static_cast<WebGPURawBuffer*>(rawBuffer);
+    buffer = webGPURawBuffer->GetBuffer();
+    offset = allocation.offset;
+    size = allocation.size;
+    temporaryAllocation = allocation.temporaryAllocation;
 }
 
 unsigned int WebGPUBuffer::GetSize() const {
@@ -68,6 +32,10 @@ unsigned int WebGPUBuffer::GetSize() const {
 
 WGPUBuffer WebGPUBuffer::GetBuffer() const {
     return buffer;
+}
+
+uint32_t WebGPUBuffer::GetOffset() const {
+    return offset;
 }
 
 } // namespace Video

--- a/src/Video/LowLevelRenderer/WebGPU/WebGPUBuffer.hpp
+++ b/src/Video/LowLevelRenderer/WebGPU/WebGPUBuffer.hpp
@@ -13,12 +13,10 @@ class WebGPUBuffer : public Buffer {
   public:
     /// Create new WebGPU buffer.
     /**
-     * @param device The WebGPU device.
      * @param bufferUsage How the buffer will be used.
-     * @param size The size of the buffer.
-     * @param data Data to initialie the buffer with.
+     * @param allocation The allocation to encapsulate.
      */
-    WebGPUBuffer(WGPUDevice device, Buffer::BufferUsage bufferUsage, uint32_t size, const void* data = nullptr);
+    WebGPUBuffer(Buffer::BufferUsage bufferUsage, const BufferAllocation& allocation);
 
     /// Destructor.
     ~WebGPUBuffer() final;
@@ -32,11 +30,20 @@ class WebGPUBuffer : public Buffer {
      */
     WGPUBuffer GetBuffer() const;
 
+    /// Get the offset into the raw buffer.
+    /**
+     * @return The offset into the raw buffer.
+     */
+    uint32_t GetOffset() const;
+
   private:
     WebGPUBuffer(const WebGPUBuffer& other) = delete;
 
+    RawBuffer* rawBuffer;
     WGPUBuffer buffer;
+    uint32_t offset = 0;
     uint32_t size = 0;
+    bool temporaryAllocation;
 };
 
 }

--- a/src/Video/LowLevelRenderer/WebGPU/WebGPUBufferAllocator.cpp
+++ b/src/Video/LowLevelRenderer/WebGPU/WebGPUBufferAllocator.cpp
@@ -1,0 +1,85 @@
+#include "WebGPUBufferAllocator.hpp"
+
+#include "WebGPUBuffer.hpp"
+#include "WebGPURenderer.hpp"
+
+namespace Video {
+
+static WGPUBufferUsageFlags GetBufferUsage(Buffer::BufferUsage bufferUsage) {
+    WGPUBufferUsageFlags usage;
+
+    switch (bufferUsage) {
+    case Buffer::BufferUsage::VERTEX_BUFFER:
+        usage = WGPUBufferUsage_Vertex;
+        break;
+    case Buffer::BufferUsage::INDEX_BUFFER:
+        usage = WGPUBufferUsage_Index;
+        break;
+    case Buffer::BufferUsage::UNIFORM_BUFFER:
+        usage = WGPUBufferUsage_Uniform | WGPUBufferUsage_CopyDst;
+        break;
+    case Buffer::BufferUsage::STORAGE_BUFFER:
+        usage = WGPUBufferUsage_Storage | WGPUBufferUsage_CopyDst;
+        break;
+    case Buffer::BufferUsage::VERTEX_STORAGE_BUFFER:
+        usage = WGPUBufferUsage_Vertex | WGPUBufferUsage_Storage | WGPUBufferUsage_CopyDst;
+        break;
+    }
+
+    // For wgpuQueueWriteBuffer.
+    usage |= WGPUBufferUsage_CopyDst;
+
+    return usage;
+}
+
+WebGPURawBuffer::WebGPURawBuffer(WebGPURenderer& webGPURenderer, Buffer::BufferUsage bufferUsage, bool temporary, unsigned int size) {
+    this->temporary = temporary;
+    queue = webGPURenderer.GetQueue();
+
+    // Create buffer.
+    WGPUBufferDescriptor bufferDescriptor = {};
+    bufferDescriptor.usage = GetBufferUsage(bufferUsage);
+    bufferDescriptor.size = size;
+
+    buffer = wgpuDeviceCreateBuffer(webGPURenderer.GetDevice(), &bufferDescriptor);
+}
+
+WebGPURawBuffer::~WebGPURawBuffer() {
+    wgpuBufferRelease(buffer);
+}
+
+void WebGPURawBuffer::Write(uint32_t offset, uint32_t size, const void* data) {
+    /// @todo Could use mapOnCreate for non-temporary buffers?
+    wgpuQueueWriteBuffer(queue, buffer, offset, data, size);
+}
+
+WGPUBuffer WebGPURawBuffer::GetBuffer() const {
+    return buffer;
+}
+
+WebGPUBufferAllocator::WebGPUBufferAllocator(WebGPURenderer& webGPURenderer) : BufferAllocator(1), webGPURenderer(webGPURenderer) {
+    
+}
+
+WebGPUBufferAllocator::~WebGPUBufferAllocator() {
+
+}
+
+uint32_t WebGPUBufferAllocator::GetAlignment(Buffer::BufferUsage bufferUsage) {
+    // Both minUniformBufferOffsetAlignment and minStorageBufferOffsetAlignment are guaranteed to be at most 256.
+    // https://www.w3.org/TR/webgpu/#dom-gpusupportedlimits-minuniformbufferoffsetalignment
+    return 256;
+}
+
+RawBuffer* WebGPUBufferAllocator::Allocate(Buffer::BufferUsage bufferUsage, bool temporary, unsigned int size) {
+    // Buffer binding sizes must be a multiple of 16.
+    size = (size + 16 - 1) / 16 * 16;
+
+    return new WebGPURawBuffer(webGPURenderer, bufferUsage, temporary, size);
+}
+
+Buffer* WebGPUBufferAllocator::CreateBufferObject(Buffer::BufferUsage bufferUsage, const BufferAllocation& allocation) {
+    return new WebGPUBuffer(bufferUsage, allocation);
+}
+
+}

--- a/src/Video/LowLevelRenderer/WebGPU/WebGPUBufferAllocator.hpp
+++ b/src/Video/LowLevelRenderer/WebGPU/WebGPUBufferAllocator.hpp
@@ -1,0 +1,61 @@
+#pragma once
+
+#include "../Interface/BufferAllocator.hpp"
+#include "WebGPU.hpp"
+
+namespace Video {
+
+class WebGPURenderer;
+
+/// WebGPU implementation of RawBuffer.
+class WebGPURawBuffer : public RawBuffer {
+  public:
+    /// Create new raw buffer used to satisfy allocations.
+    /**
+     * @param webGPURenderer The WebGPU renderer.
+     * @param bufferUsage How the buffer will be used.
+     * @param temporary Whether the buffer is going to be used to satisfy temporary allocations.
+     * @param size The size of the buffer in bytes.
+     */
+    WebGPURawBuffer(WebGPURenderer& webGPURenderer, Buffer::BufferUsage bufferUsage, bool temporary, unsigned int size);
+
+    /// Destructor.
+    ~WebGPURawBuffer() final;
+
+    void Write(uint32_t offset, uint32_t size, const void* data) final;
+
+    /// Get the internal WebGPU buffer.
+    /**
+     * @return The internal WebGPU buffer.
+     */
+    WGPUBuffer GetBuffer() const;
+
+  private:
+    WGPUBuffer buffer;
+    WGPUQueue queue;
+    bool temporary;
+};
+
+/// WebGPU implementation of BufferAllocator.
+class WebGPUBufferAllocator : public BufferAllocator {
+  public:
+    /// Create a new buffer allocator.
+    /**
+     * @param webGPURenderer The WebGPU renderer.
+     */
+    explicit WebGPUBufferAllocator(WebGPURenderer& webGPURenderer);
+
+    /// Destructor.
+    ~WebGPUBufferAllocator() final;
+
+  private:
+    WebGPUBufferAllocator(const WebGPUBufferAllocator& other) = delete;
+
+    uint32_t GetAlignment(Buffer::BufferUsage bufferUsage) final;
+    RawBuffer* Allocate(Buffer::BufferUsage bufferUsage, bool temporary, unsigned int size) final;
+    Buffer* CreateBufferObject(Buffer::BufferUsage bufferUsage, const BufferAllocation& allocation) final;
+
+    WebGPURenderer& webGPURenderer;
+};
+
+}

--- a/src/Video/LowLevelRenderer/WebGPU/WebGPUCommandBuffer.cpp
+++ b/src/Video/LowLevelRenderer/WebGPU/WebGPUCommandBuffer.cpp
@@ -253,6 +253,7 @@ void WebGPUCommandBuffer::BindUniformBuffer(ShaderProgram::BindingType bindingTy
     entry.binding = 0;
     entry.buffer = static_cast<const WebGPUBuffer*>(uniformBuffer)->GetBuffer();
     entry.size = uniformBuffer->GetSize();
+    entry.offset = static_cast<const WebGPUBuffer*>(uniformBuffer)->GetOffset();
 
     WGPUBindGroupDescriptor bindGroupDescriptor = {};
     bindGroupDescriptor.layout = currentGraphicsPipeline->GetShaderProgram()->GetBindGroupLayouts()[bindingType];
@@ -280,6 +281,7 @@ void WebGPUCommandBuffer::BindStorageBuffers(std::initializer_list<Buffer*> buff
         entries[i].binding = i;
         entries[i].buffer = static_cast<const WebGPUBuffer*>(buffer)->GetBuffer();
         entries[i].size = buffer->GetSize();
+        entries[i].offset = static_cast<const WebGPUBuffer*>(buffer)->GetOffset();
 
         ++i;
     }
@@ -554,6 +556,7 @@ void WebGPUCommandBuffer::UpdateUniforms() {
         entries[bindGroupDescriptor.entryCount].binding = 0;
         entries[bindGroupDescriptor.entryCount].buffer = currentUniformBuffer->GetBuffer();
         entries[bindGroupDescriptor.entryCount].size = currentUniformBuffer->GetSize();
+        entries[bindGroupDescriptor.entryCount].offset = currentUniformBuffer->GetOffset();
 
         ++bindGroupDescriptor.entryCount;
     }

--- a/src/Video/LowLevelRenderer/WebGPU/WebGPURenderer.hpp
+++ b/src/Video/LowLevelRenderer/WebGPU/WebGPURenderer.hpp
@@ -13,6 +13,7 @@ class Window;
 namespace Video {
 
 class WebGPUBuffer;
+class WebGPUBufferAllocator;
 class WebGPUSampler;
 class WebGPURenderTargetAllocator;
 class WebGPUTexture;
@@ -116,8 +117,6 @@ class WebGPURenderer : public LowLevelRenderer {
     void CreateSwapChain(::Utility::Window* window);
     void CreateSamplers();
 
-    void ReleaseTemporaryBuffers();
-
     WGPUInstance instance;
     WGPUSurface surface;
     WGPUAdapter adapter;
@@ -128,14 +127,13 @@ class WebGPURenderer : public LowLevelRenderer {
 
     WebGPUSampler* samplers[static_cast<uint32_t>(Sampler::Filter::COUNT) * static_cast<uint32_t>(Sampler::Clamping::COUNT)];
     
+    WebGPUBufferAllocator* bufferAllocator;
     WebGPURenderTargetAllocator* renderTargetAllocator;
 
     OptionalFeatures optionalFeatures;
 
     glm::uvec2 swapChainSize;
     WGPUTextureFormat swapChainFormat;
-
-    std::vector<WebGPUBuffer*> temporaryBuffers;
 
     // Blitting to swap chain.
     Shader* blitVertexShader;


### PR DESCRIPTION
Make the WebGPU implementation use the same buffer allocation strategy as Vulkan and OpenGL. This means reusing buffers to satisfy temporary buffer requests instead of creating and destroying buffers every frame.

Also introduce a new alternative buffer allocation strategy, which reuses buffers but does not suballocate from larger buffers. The idea is to let the WebGPU implementation handle suballocation, eg. using Vulkan Memory Allocator.