### PR TITLE
Use wgpuQueueOnSubmittedWorkDone in wgpu

### DIFF
--- a/src/Video/LowLevelRenderer/WebGPU/WebGPURenderer.cpp
+++ b/src/Video/LowLevelRenderer/WebGPU/WebGPURenderer.cpp
@@ -178,13 +178,6 @@ ComputePipeline* WebGPURenderer::CreateComputePipeline(const ShaderProgram* shad
 }
 
 void WebGPURenderer::Wait() {
-#if WEBGPU_BACKEND_WGPU
-    // wgpu-native doesn't currently implement wgpuQueueOnSubmittedWorkDone. Just wait for an arbitrary amount of time instead.
-    /// @todo Remove once wgpu-native adds it.
-    std::this_thread::sleep_for(std::chrono::duration<int>(1));
-    return;
-#endif
-
     std::atomic<bool> finished = false;
     wgpuQueueOnSubmittedWorkDone(
         queue,


### PR DESCRIPTION
Previously, wgpuQueueOnSubmittedWorkDone had not been implemented in wgpu-native, so instead of using it to determine when GPU work has finished, a simple sleep was done. Now that wgpuQueueOnSubmittedWorkDone has been implemented, remove this workaround.